### PR TITLE
Use `np.version.version` instead of `np.__version__`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Thanks to Michiaki Ariga, there is now a
 
    .. code-block:: python
 
-      print(np.__version__)
+      print(np.version.version)
       np.show_config()
 
 


### PR DESCRIPTION
For printing the numpy version, the public `np.version.version` seems preferable to the current answer.