### PR TITLE
Correcting solution to the 'round away from 0' exercise

### DIFF
--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -585,7 +585,7 @@
     "# Author: Charles R Harris\n",
     "\n",
     "Z = np.random.uniform(-10,+10,10)\n",
-    "print (np.trunc(Z + np.copysign(0.5, Z)))"
+    "print (np.copysign(np.ceil(np.abs(Z)), Z))"
    ]
   },
   {

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -260,7 +260,7 @@ print(np.array([np.nan]).astype(int).astype(float))
 # Author: Charles R Harris
 
 Z = np.random.uniform(-10,+10,10)
-print (np.trunc(Z + np.copysign(0.5, Z)))
+print (np.copysign(np.ceil(np.abs(Z)), Z))
 ```
 
 #### 30. How to find common values between two arrays? (★☆☆)


### PR DESCRIPTION
Exercise: How to round away from zero a float array?
Problem:
Z = np.array([1.4])
np.trunc(Z + np.copysign(0.5, Z)) # prints 1. instead of 2.
Z = np.array([1.0])
np.round(Z + np.copysign(0.5, Z)) # prints 2. instead of 1.
Solution:
Z = np.array([1.0, 1.4])
np.copysign(np.ceil(np.abs(Z)), Z) # prints correct [1., 2.]