### PR TITLE
detail: improved readability for 'point by point distances' exercise

### DIFF
--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -1076,7 +1076,7 @@
    "outputs": [],
    "source": [
     "Z = np.random.random((10,2))\n",
-    "X,Y = np.atleast_2d(Z[:,0]), np.atleast_2d(Z[:,1])\n",
+    "X,Y = np.atleast_2d(Z[:,0], Z[:,1])\n",
     "D = np.sqrt( (X-X.T)**2 + (Y-Y.T)**2)\n",
     "print(D)\n",
     "\n",

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -498,7 +498,7 @@ print(Z)
 
 ```python
 Z = np.random.random((10,2))
-X,Y = np.atleast_2d(Z[:,0]), np.atleast_2d(Z[:,1])
+X,Y = np.atleast_2d(Z[:,0], Z[:,1])
 D = np.sqrt( (X-X.T)**2 + (Y-Y.T)**2)
 print(D)
 


### PR DESCRIPTION
numpy.atleast_2d() can take multiple arguments so both arrays can be passed in one function call