### PR TITLE
adding a simpler solution to 'sum over last two axes' exercise'

### DIFF
--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -1436,6 +1436,11 @@
    "outputs": [],
    "source": [
     "A = np.random.randint(0,10,(3,4,3,4))\n",
+	"# solution by passing a tuple of axes\n",
+	"sum = A.sum(axis=(-2,-1))\n",
+	"print(sum)\n",
+	"# solution by flattening the last two dimensions into one\n",
+	"# (useful for functions that don't accept tuples for axis argument)\n",
     "sum = A.reshape(A.shape[:-2] + (-1,)).sum(axis=-1)\n",
     "print(sum)"
    ]

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -693,6 +693,11 @@ print(np.unique(I))
 
 ```python
 A = np.random.randint(0,10,(3,4,3,4))
+# solution by passing a tuple of axes
+sum = A.sum(axis=(-2,-1))
+print(sum)
+# solution by flattening the last two dimensions into one
+# (useful for functions that don't accept tuples for axis argument)
 sum = A.reshape(A.shape[:-2] + (-1,)).sum(axis=-1)
 print(sum)
 ```


### PR DESCRIPTION
Numpy.sum accepts a tuple of integers for the axis argument. This allows to apply sum over a set of axes in one go.
Jupyter notebook tested OK.