### PR TITLE
generalizing the solution to the 'extract rows with unequal values'

### DIFF
--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -2149,6 +2149,12 @@
     "# Author: Robert Kern\n",
     "\n",
     "Z = np.random.randint(0,5,(10,3))\n",
+    "print(Z)\n",
+    "# solution for arrays of all dtypes (including string arrays and record arrays)\n",
+    "E = np.all(Z[:,1:] == Z[:,:-1], axis=1)\n",
+    "U = Z[~E]\n",
+    "print(U)\n",
+    "# soluiton for numerical arrays only, will work for any number of columns in Z\n",
     "U = Z[Z.max(axis=1) != Z.min(axis=1),:]\n",
     "print(U)"
    ]

--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -2149,9 +2149,7 @@
     "# Author: Robert Kern\n",
     "\n",
     "Z = np.random.randint(0,5,(10,3))\n",
-    "E = np.logical_and.reduce(Z[:,1:] == Z[:,:-1], axis=1)\n",
-    "U = Z[~E]\n",
-    "print(Z)\n",
+    "U = Z[Z.max(axis=1) != Z.min(axis=1),:]\n",
     "print(U)"
    ]
   },

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -1108,6 +1108,12 @@ print(rows)
 # Author: Robert Kern
 
 Z = np.random.randint(0,5,(10,3))
+print(Z)
+# solution for arrays of all dtypes (including string arrays and record arrays)
+E = np.all(Z[:,1:] == Z[:,:-1], axis=1)
+U = Z[~E]
+print(U)
+# soluiton for numerical arrays only, will work for any number of columns in Z
 U = Z[Z.max(axis=1) != Z.min(axis=1),:]
 print(U)
 ```

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -1108,9 +1108,7 @@ print(rows)
 # Author: Robert Kern
 
 Z = np.random.randint(0,5,(10,3))
-E = np.logical_and.reduce(Z[:,1:] == Z[:,:-1], axis=1)
-U = Z[~E]
-print(Z)
+U = Z[Z.max(axis=1) != Z.min(axis=1),:]
 print(U)
 ```
 


### PR DESCRIPTION
The current solution is correct but can be generalized. It works only for arrays having 3 columns and can't be easily extended. I provide a solution that works for any number of columns and seems to be simpler.

Also a side note, `np.logical_and.reduce()` is equivalent to `np.all()`.