### PR TITLE
correcting einsum equivalent of outer function

### DIFF
--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -2234,7 +2234,7 @@
     "np.einsum('i->', A)       # np.sum(A)\n",
     "np.einsum('i,i->i', A, B) # A * B\n",
     "np.einsum('i,i', A, B)    # np.inner(A, B)\n",
-    "np.einsum('i,j', A, B)    # np.outer(A, B)"
+    "np.einsum('i,j->ij', A, B)    # np.outer(A, B)"
    ]
   },
   {

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -1160,7 +1160,7 @@ B = np.random.uniform(0,1,10)
 np.einsum('i->', A)       # np.sum(A)
 np.einsum('i,i->i', A, B) # A * B
 np.einsum('i,i', A, B)    # np.inner(A, B)
-np.einsum('i,j', A, B)    # np.outer(A, B)
+np.einsum('i,j->ij', A, B)    # np.outer(A, B)
 ```
 
 #### 98. Considering a path described by two vectors (X,Y), how to sample it using equidistant samples (★★★)?


### PR DESCRIPTION
Currently the code is `np.einsum('i,j->', A, B)` which is equivalent to `np.sum(np.outer(A, B))`.