### PR TITLE
Shortened code lines (partly using yapf), wrapped comments

### DIFF
--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -33,7 +33,7 @@ print(Z)
 
 
 ```python
-Z = np.zeros((10,10))
+Z = np.zeros((10, 10))
 print("%d bytes" % (Z.size * Z.itemsize))
 ```
 
@@ -41,7 +41,7 @@ print("%d bytes" % (Z.size * Z.itemsize))
 
 
 ```python
-%run `python -c "import numpy; numpy.info(numpy.add)"`
+$ python -c "import numpy; numpy.info(numpy.add)"
 ```
 
 #### 6.  Create a null vector of size 10 but the fifth value which is 1 (★☆☆)
@@ -57,7 +57,7 @@ print(Z)
 
 
 ```python
-Z = np.arange(10,50)
+Z = np.arange(10, 50)
 print(Z)
 ```
 
@@ -74,15 +74,15 @@ print(Z)
 
 
 ```python
-Z = np.arange(9).reshape(3,3)
+Z = np.arange(9).reshape(3, 3)
 print(Z)
 ```
 
-#### 10. Find indices of non-zero elements from \[1,2,0,0,4,0\] (★☆☆)
+#### 10. Find indices of non-zero elements from \[1, 2, 0, 0, 4, 0\] (★☆☆)
 
 
 ```python
-nz = np.nonzero([1,2,0,0,4,0])
+nz = np.nonzero([1, 2, 0, 0, 4, 0])
 print(nz)
 ```
 
@@ -98,7 +98,7 @@ print(Z)
 
 
 ```python
-Z = np.random.random((3,3,3))
+Z = np.random.random((3, 3, 3))
 print(Z)
 ```
 
@@ -106,7 +106,7 @@ print(Z)
 
 
 ```python
-Z = np.random.random((10,10))
+Z = np.random.random((10, 10))
 Zmin, Zmax = Z.min(), Z.max()
 print(Zmin, Zmax)
 ```
@@ -124,8 +124,8 @@ print(m)
 
 
 ```python
-Z = np.ones((10,10))
-Z[1:-1,1:-1] = 0
+Z = np.ones((10, 10))
+Z[1:-1, 1:-1] = 0
 print(Z)
 ```
 
@@ -133,8 +133,9 @@ print(Z)
 
 
 ```python
-Z = np.ones((5,5))
-Z = np.pad(Z, pad_width=1, mode='constant', constant_values=0)
+Z = np.ones((5, 5))
+Z = np.pad(Z, pad_width=1, mode='constant',
+  constant_values=0)
 print(Z)
 ```
 
@@ -149,11 +150,11 @@ print(np.nan - np.nan)
 print(0.3 == 3 * 0.1)
 ```
 
-#### 18. Create a 5x5 matrix with values 1,2,3,4 just below the diagonal (★☆☆)
+#### 18. Create a 5x5 matrix with values 1, 2, 3, 4 just below the diagonal (★☆☆)
 
 
 ```python
-Z = np.diag(1+np.arange(4),k=-1)
+Z = np.diag(1 + np.arange(4), k=-1)
 print(Z)
 ```
 
@@ -161,24 +162,24 @@ print(Z)
 
 
 ```python
-Z = np.zeros((8,8),dtype=int)
-Z[1::2,::2] = 1
-Z[::2,1::2] = 1
+Z = np.zeros((8, 8), dtype=int)
+Z[1::2, ::2] = 1
+Z[::2, 1::2] = 1
 print(Z)
 ```
 
-#### 20. Consider a (6,7,8) shape array, what is the index (x,y,z) of the 100th element?
+#### 20. Consider a (6, 7, 8) shape array, what is the index (x, y, z) of the 100th element?
 
 
 ```python
-print(np.unravel_index(100,(6,7,8)))
+print(np.unravel_index(100, (6, 7, 8)))
 ```
 
 #### 21. Create a checkerboard 8x8 matrix using the tile function (★☆☆)
 
 
 ```python
-Z = np.tile( np.array([[0,1],[1,0]]), (4,4))
+Z = np.tile(np.array([[0, 1], [1, 0]]), (4, 4))
 print(Z)
 ```
 
@@ -186,9 +187,9 @@ print(Z)
 
 
 ```python
-Z = np.random.random((5,5))
+Z = np.random.random((5, 5))
 Zmax, Zmin = Z.max(), Z.min()
-Z = (Z - Zmin)/(Zmax - Zmin)
+Z = (Z - Zmin) / (Zmax - Zmin)
 print(Z)
 ```
 
@@ -206,11 +207,11 @@ color = np.dtype([("r", np.ubyte, 1),
 
 
 ```python
-Z = np.dot(np.ones((5,3)), np.ones((3,2)))
+Z = np.dot(np.ones((5, 3)), np.ones((3, 2)))
 print(Z)
 
-# Alternative solution, in Python 3.5 and above
-Z = np.ones((5,3)) @ np.ones((3,2))
+# Alternative solution, in Python >= 3.5
+Z = np.ones((5, 3)) @ np.ones((3, 2))
 print(Z)
 ```
 
@@ -231,9 +232,9 @@ print(Z)
 ```python
 # Author: Jake VanderPlas
 
-print(sum(range(5),-1))
+print(sum(range(5), -1))
 from numpy import *
-print(sum(range(5),-1))
+print(sum(range(5), -1))
 ```
 
 #### 27. Consider an integer vector Z, which of these expressions are legal? (★☆☆)
@@ -242,10 +243,10 @@ print(sum(range(5),-1))
 ```python
 Z**Z
 2 << Z >> 2
-Z <- Z
-1j*Z
-Z/1/1
-Z<Z>Z
+Z < -Z
+1j * Z
+Z / 1 / 1
+Z < Z > Z
 ```
 
 #### 28. What are the result of the following expressions?
@@ -257,23 +258,23 @@ print(np.array(0) // np.array(0))
 print(np.array([np.nan]).astype(int).astype(float))
 ```
 
-#### 29. How to round away from zero a float array ? (★☆☆)
+#### 29. How to round away from zero a float array? (★☆☆)
 
 
 ```python
 # Author: Charles R Harris
 
-Z = np.random.uniform(-10,+10,10)
-print (np.copysign(np.ceil(np.abs(Z)), Z))
+Z = np.random.uniform(-10, +10, 10)
+print(np.copysign(np.ceil(np.abs(Z)), Z))
 ```
 
 #### 30. How to find common values between two arrays? (★☆☆)
 
 
 ```python
-Z1 = np.random.randint(0,10,10)
-Z2 = np.random.randint(0,10,10)
-print(np.intersect1d(Z1,Z2))
+Z1 = np.random.randint(0, 10, 10)
+Z2 = np.random.randint(0, 10, 10)
+print(np.intersect1d(Z1, Z2))
 ```
 
 #### 31. How to ignore all numpy warnings (not recommended)? (★☆☆)
@@ -286,13 +287,10 @@ Z = np.ones(1) / 0
 
 # Back to sanity
 _ = np.seterr(**defaults)
-```
 
-An equivalent way, with a context manager:
-
-```python
+# An equivalent way, with a context manager:
 with np.errstate(divide='ignore'):
-    Z = np.ones(1) / 0
+  Z = np.ones(1) / 0
 ```
 
 #### 32. Is the following expressions true? (★☆☆)
@@ -306,16 +304,17 @@ np.sqrt(-1) == np.emath.sqrt(-1)
 
 
 ```python
-yesterday = np.datetime64('today', 'D') - np.timedelta64(1, 'D')
 today     = np.datetime64('today', 'D')
-tomorrow  = np.datetime64('today', 'D') + np.timedelta64(1, 'D')
+yesterday = today - np.timedelta64(1, 'D')
+tomorrow  = today + np.timedelta64(1, 'D')
 ```
 
 #### 34. How to get all the dates corresponding to the month of July 2016? (★★☆)
 
 
 ```python
-Z = np.arange('2016-07', '2016-08', dtype='datetime64[D]')
+Z = np.arange(
+  '2016-07', '2016-08', dtype='datetime64[D]')
 print(Z)
 ```
 
@@ -323,33 +322,33 @@ print(Z)
 
 
 ```python
-A = np.ones(3)*1
-B = np.ones(3)*2
-C = np.ones(3)*3
-np.add(A,B,out=B)
-np.divide(A,2,out=A)
-np.negative(A,out=A)
-np.multiply(A,B,out=A)
+A = np.ones(3) * 1
+B = np.ones(3) * 2
+C = np.ones(3) * 3
+np.add(A, B, out=B)
+np.divide(A, 2, out=A)
+np.negative(A, out=A)
+np.multiply(A, B, out=A)
 ```
 
 #### 36. Extract the integer part of a random array using 5 different methods (★★☆)
 
 
 ```python
-Z = np.random.uniform(0,10,10)
+Z = np.random.uniform(0, 10, 10)
 
-print (Z - Z%1)
-print (np.floor(Z))
-print (np.ceil(Z)-1)
-print (Z.astype(int))
-print (np.trunc(Z))
+print(Z - Z % 1)
+print(np.floor(Z))
+print(np.ceil(Z) - 1)
+print(Z.astype(int))
+print(np.trunc(Z))
 ```
 
 #### 37. Create a 5x5 matrix with row values ranging from 0 to 4 (★★☆)
 
 
 ```python
-Z = np.zeros((5,5))
+Z = np.zeros((5, 5))
 Z += np.arange(5)
 print(Z)
 ```
@@ -359,9 +358,11 @@ print(Z)
 
 ```python
 def generate():
-    for x in range(10):
-        yield x
-Z = np.fromiter(generate(),dtype=float,count=-1)
+  for x in range(10):
+    yield x
+
+Z = np.fromiter(
+  generate(), dtype=float, count=-1)
 print(Z)
 ```
 
@@ -369,7 +370,7 @@ print(Z)
 
 
 ```python
-Z = np.linspace(0,1,12,endpoint=True)[1:-1]
+Z = np.linspace(0, 1, 12, endpoint=True)[1:-1]
 print(Z)
 ```
 
@@ -392,19 +393,21 @@ Z = np.arange(10)
 np.add.reduce(Z)
 ```
 
-#### 42. Consider two random array A anb B, check if they are equal (★★☆)
+#### 42. Consider two random array A and B, check if they are equal (★★☆)
 
 
 ```python
-A = np.random.randint(0,2,5)
-B = np.random.randint(0,2,5)
+A = np.random.randint(0, 2, 5)
+B = np.random.randint(0, 2, 5)
 
-# Assuming identical shape of the arrays and a tolerance for the comparison of values
-equal = np.allclose(A,B)
+# Assuming identical shape of the arrays
+# and a tolerance for the comparison of values
+equal = np.allclose(A, B)
 print(equal)
 
-# Checking both the shape and the element values, no tolerance (values have to be exactly equal)
-equal = np.array_equal(A,B)
+# Checking both the shape and the element values,
+# no tolerance (values have to be exactly equal)
+equal = np.array_equal(A, B)
 print(equal)
 ```
 
@@ -421,10 +424,10 @@ Z[0] = 1
 
 
 ```python
-Z = np.random.random((10,2))
-X,Y = Z[:,0], Z[:,1]
-R = np.sqrt(X**2+Y**2)
-T = np.arctan2(Y,X)
+Z = np.random.random((10, 2))
+X, Y = Z[:, 0], Z[:, 1]
+R = np.sqrt(X**2 + Y**2)
+T = np.arctan2(Y, X)
 print(R)
 print(T)
 ```
@@ -438,13 +441,14 @@ Z[Z.argmax()] = 0
 print(Z)
 ```
 
-#### 46. Create a structured array with `x` and `y` coordinates covering the \[0,1\]x\[0,1\] area (★★☆)
+#### 46. Create a structured array with `x` and `y` coordinates covering the \[0, 1\]x\[0, 1\] area (★★☆)
 
 
 ```python
-Z = np.zeros((5,5), [('x',float),('y',float)])
-Z['x'], Z['y'] = np.meshgrid(np.linspace(0,1,5),
-                             np.linspace(0,1,5))
+Z = np.zeros((5, 5), [('x', float), ('y', float)])
+Z['x'], Z['y'] = np.meshgrid(
+  np.linspace(0, 1, 5),
+  np.linspace(0, 1, 5))
 print(Z)
 ```
 
@@ -467,6 +471,7 @@ print(np.linalg.det(C))
 for dtype in [np.int8, np.int32, np.int64]:
    print(np.iinfo(dtype).min)
    print(np.iinfo(dtype).max)
+
 for dtype in [np.float32, np.float64]:
    print(np.finfo(dtype).min)
    print(np.finfo(dtype).max)
@@ -478,7 +483,7 @@ for dtype in [np.float32, np.float64]:
 
 ```python
 np.set_printoptions(threshold=np.nan)
-Z = np.zeros((16,16))
+Z = np.zeros((16, 16))
 print(Z)
 ```
 
@@ -487,30 +492,32 @@ print(Z)
 
 ```python
 Z = np.arange(100)
-v = np.random.uniform(0,100)
-index = (np.abs(Z-v)).argmin()
+v = np.random.uniform(0, 100)
+index = (np.abs(Z - v)).argmin()
 print(Z[index])
 ```
 
-#### 51. Create a structured array representing a position (x,y) and a color (r,g,b) (★★☆)
+#### 51. Create a structured array representing a position (x, y) and a color (r, g, b) (★★☆)
 
 
 ```python
-Z = np.zeros(10, [ ('position', [ ('x', float, 1),
-                                  ('y', float, 1)]),
-                   ('color',    [ ('r', float, 1),
-                                  ('g', float, 1),
-                                  ('b', float, 1)])])
+Z = np.zeros(
+  10, [('position', [('x', float, 1),
+                     ('y', float, 1)]),
+       ('color',    [('r', float, 1),
+                     ('g', float, 1),
+                     ('b', float, 1)])]
+)
 print(Z)
 ```
 
-#### 52. Consider a random vector with shape (100,2) representing coordinates, find point by point distances (★★☆)
+#### 52. Consider a random vector with shape (100, 2) representing coordinates, find point by point distances (★★☆)
 
 
 ```python
-Z = np.random.random((10,2))
-X,Y = np.atleast_2d(Z[:,0], Z[:,1])
-D = np.sqrt( (X-X.T)**2 + (Y-Y.T)**2)
+Z = np.random.random((10, 2))
+X, Y = np.atleast_2d(Z[:, 0], Z[:, 1])
+D = np.sqrt((X - X.T)**2 + (Y - Y.T)**2)
 print(D)
 
 # Much faster with scipy
@@ -518,8 +525,8 @@ import scipy
 # Thanks Gavin Heverly-Coulson (#issue 1)
 import scipy.spatial
 
-Z = np.random.random((10,2))
-D = scipy.spatial.distance.cdist(Z,Z)
+Z = np.random.random((10, 2))
+D = scipy.spatial.distance.cdist(Z, Z)
 print(D)
 ```
 
@@ -542,7 +549,8 @@ from io import StringIO
 s = StringIO("""1, 2, 3, 4, 5\n
                 6,  ,  , 7, 8\n
                  ,  , 9,10,11\n""")
-Z = np.genfromtxt(s, delimiter=",", dtype=np.int)
+Z = np.genfromtxt(
+  s, delimiter=",", dtype=np.int)
 print(Z)
 ```
 
@@ -550,9 +558,11 @@ print(Z)
 
 
 ```python
-Z = np.arange(9).reshape(3,3)
+Z = np.arange(9).reshape(3, 3)
+
 for index, value in np.ndenumerate(Z):
     print(index, value)
+
 for index in np.ndindex(Z.shape):
     print(index, Z[index])
 ```
@@ -561,10 +571,12 @@ for index in np.ndindex(Z.shape):
 
 
 ```python
-X, Y = np.meshgrid(np.linspace(-1,1,10), np.linspace(-1,1,10))
-D = np.sqrt(X*X+Y*Y)
+X, Y = np.meshgrid(
+  np.linspace(-1, 1, 10),
+  np.linspace(-1, 1, 10))
+D = np.sqrt(X * X + Y * Y)
 sigma, mu = 1.0, 0.0
-G = np.exp(-( (D-mu)**2 / ( 2.0 * sigma**2 ) ) )
+G = np.exp(-((D - mu)**2 / (2.0 * sigma**2)))
 print(G)
 ```
 
@@ -576,8 +588,9 @@ print(G)
 
 n = 10
 p = 3
-Z = np.zeros((n,n))
-np.put(Z, np.random.choice(range(n*n), p, replace=False),1)
+Z = np.zeros((n, n))
+np.put(Z, np.random.choice(
+  range(n * n), p, replace=False), 1)
 print(Z)
 ```
 
@@ -604,9 +617,9 @@ print(Y)
 ```python
 # Author: Steve Tjoa
 
-Z = np.random.randint(0,10,(3,3))
+Z = np.random.randint(0, 10, (3, 3))
 print(Z)
-print(Z[Z[:,1].argsort()])
+print(Z[Z[:, 1].argsort()])
 ```
 
 #### 60. How to tell if a given 2D array has null columns? (★★☆)
@@ -615,7 +628,7 @@ print(Z[Z[:,1].argsort()])
 ```python
 # Author: Warren Weckesser
 
-Z = np.random.randint(0,3,(3,10))
+Z = np.random.randint(0, 3, (3, 10))
 print((~Z.any(axis=0)).any())
 ```
 
@@ -623,20 +636,22 @@ print((~Z.any(axis=0)).any())
 
 
 ```python
-Z = np.random.uniform(0,1,10)
+Z = np.random.uniform(0, 1, 10)
 z = 0.5
 m = Z.flat[np.abs(Z - z).argmin()]
 print(m)
 ```
 
-#### 62. Considering two arrays with shape (1,3) and (3,1), how to compute their sum using an iterator? (★★☆)
+#### 62. Considering two arrays with shape (1, 3) and (3, 1), how to compute their sum using an iterator? (★★☆)
 
 
 ```python
-A = np.arange(3).reshape(3,1)
-B = np.arange(3).reshape(1,3)
-it = np.nditer([A,B,None])
-for x,y,z in it: z[...] = x + y
+A = np.arange(3).reshape(3, 1)
+B = np.arange(3).reshape(1, 3)
+it = np.nditer([A, B, None])
+for x, y, z in it:
+  z[...] = x + y
+
 print(it.operands[2])
 ```
 
@@ -645,16 +660,17 @@ print(it.operands[2])
 
 ```python
 class NamedArray(np.ndarray):
-    def __new__(cls, array, name="no name"):
-        obj = np.asarray(array).view(cls)
-        obj.name = name
-        return obj
-    def __array_finalize__(self, obj):
-        if obj is None: return
-        self.info = getattr(obj, 'name', "no name")
+  def __new__(cls, array, name="no name"):
+    obj = np.asarray(array).view(cls)
+    obj.name = name
+    return obj
+
+  def __array_finalize__(self, obj):
+    if obj is None: return
+    self.info = getattr(obj, 'name', "no name")
 
 Z = NamedArray(np.arange(10), "range_10")
-print (Z.name)
+print(Z.name)
 ```
 
 #### 64. Consider a given vector, how to add 1 to each element indexed by a second vector (be careful with repeated indices)? (★★★)
@@ -664,7 +680,7 @@ print (Z.name)
 # Author: Brett Olsen
 
 Z = np.ones(10)
-I = np.random.randint(0,len(Z),20)
+I = np.random.randint(0, len(Z), 20)
 Z += np.bincount(I, minlength=len(Z))
 print(Z)
 
@@ -680,21 +696,24 @@ print(Z)
 ```python
 # Author: Alan G Isaac
 
-X = [1,2,3,4,5,6]
-I = [1,3,9,3,4,1]
-F = np.bincount(I,X)
+X = [1, 2, 3, 4, 5, 6]
+I = [1, 3, 9, 3, 4, 1]
+F = np.bincount(I, X)
 print(F)
 ```
 
-#### 66. Considering a (w,h,3) image of (dtype=ubyte), compute the number of unique colors (★★★)
+#### 66. Considering a (w, h, 3) image of (dtype=ubyte), compute the number of unique colors (★★★)
 
 
 ```python
 # Author: Nadav Horesh
 
-w,h = 16,16
-I = np.random.randint(0,2,(h,w,3)).astype(np.ubyte)
-F = I[...,0]*256*256 + I[...,1]*256 +I[...,2]
+w, h = 16, 16
+I = np.random.randint(
+  0, 2, (h, w, 3)).astype(np.ubyte)
+F = I[..., 0] * 256 * 256 +
+    I[..., 1] * 256 +
+    I[..., 2]
 n = len(np.unique(F))
 print(np.unique(I))
 ```
@@ -703,30 +722,34 @@ print(np.unique(I))
 
 
 ```python
-A = np.random.randint(0,10,(3,4,3,4))
-# solution by passing a tuple of axes (introduced in numpy 1.7.0)
-sum = A.sum(axis=(-2,-1))
+A = np.random.randint(0, 10, (3, 4, 3, 4))
+# solution by passing a tuple of axes
+# (introduced in numpy 1.7.0)
+sum = A.sum(axis=(-2, -1))
 print(sum)
-# solution by flattening the last two dimensions into one
-# (useful for functions that don't accept tuples for axis argument)
-sum = A.reshape(A.shape[:-2] + (-1,)).sum(axis=-1)
+# solution by flattening the last two
+# dimensions into one (useful for functions
+# that don't accept tuples for axis argument)
+sum = A.reshape(
+  A.shape[:-2] + (-1, )).sum(axis=-1)
 print(sum)
 ```
 
-#### 68. Considering a one-dimensional vector D, how to compute means of subsets of D using a vector S of same size describing subset  indices? (★★★)
+#### 68. Considering a one-dimensional vector D, how to compute means of subsets of D using a vector S of same size describing subset indices? (★★★)
 
 
 ```python
 # Author: Jaime Fernández del Río
 
-D = np.random.uniform(0,1,100)
-S = np.random.randint(0,10,100)
+D = np.random.uniform(0, 1, 100)
+S = np.random.randint(0, 10, 100)
 D_sums = np.bincount(S, weights=D)
 D_counts = np.bincount(S)
 D_means = D_sums / D_counts
 print(D_means)
 
-# Pandas solution as a reference due to more intuitive code
+# Pandas solution as a reference
+# due to more intuitive code
 import pandas as pd
 print(pd.Series(D).groupby(S).mean())
 ```
@@ -737,8 +760,8 @@ print(pd.Series(D).groupby(S).mean())
 ```python
 # Author: Mathieu Blondel
 
-A = np.random.uniform(0,1,(5,5))
-B = np.random.uniform(0,1,(5,5))
+A = np.random.uniform(0, 1, (5, 5))
+B = np.random.uniform(0, 1, (5, 5))
 
 # Slow version  
 np.diag(np.dot(A, B))
@@ -756,20 +779,20 @@ np.einsum("ij,ji->i", A, B)
 ```python
 # Author: Warren Weckesser
 
-Z = np.array([1,2,3,4,5])
+Z = np.array([1, 2, 3, 4, 5])
 nz = 3
-Z0 = np.zeros(len(Z) + (len(Z)-1)*(nz))
-Z0[::nz+1] = Z
+Z0 = np.zeros(len(Z) + (len(Z) - 1) * (nz))
+Z0[::nz + 1] = Z
 print(Z0)
 ```
 
-#### 71. Consider an array of dimension (5,5,3), how to mulitply it by an array with dimensions (5,5)? (★★★)
+#### 71. Consider an array of dimension (5, 5, 3), how to mulitply it by an array with dimensions (5, 5)? (★★★)
 
 
 ```python
-A = np.ones((5,5,3))
-B = 2*np.ones((5,5))
-print(A * B[:,:,None])
+A = np.ones((5, 5, 3))
+B = 2 * np.ones((5, 5))
+print(A * B[:, :, None])
 ```
 
 #### 72. How to swap two rows of an array? (★★★)
@@ -778,22 +801,23 @@ print(A * B[:,:,None])
 ```python
 # Author: Eelco Hoogendoorn
 
-A = np.arange(25).reshape(5,5)
-A[[0,1]] = A[[1,0]]
+A = np.arange(25).reshape(5, 5)
+A[[0, 1]] = A[[1, 0]]
 print(A)
 ```
 
-#### 73. Consider a set of 10 triplets describing 10 triangles (with shared vertices), find the set of unique line segments composing all the  triangles (★★★)
+#### 73. Consider a set of 10 triplets describing 10 triangles (with shared vertices), find the set of unique line segments composing all the triangles (★★★)
 
 
 ```python
 # Author: Nicolas P. Rougier
 
-faces = np.random.randint(0,100,(10,3))
-F = np.roll(faces.repeat(2,axis=1),-1,axis=1)
-F = F.reshape(len(F)*3,2)
-F = np.sort(F,axis=1)
-G = F.view( dtype=[('p0',F.dtype),('p1',F.dtype)] )
+faces = np.random.randint(0, 100, (10, 3))
+F = np.roll(faces.repeat(2, axis=1), -1, axis=1)
+F = F.reshape(len(F) * 3, 2)
+F = np.sort(F, axis=1)
+G = F.view(dtype=[('p0', F.dtype),
+                  ('p1', F.dtype)])
 G = np.unique(G)
 print(G)
 ```
@@ -804,7 +828,7 @@ print(G)
 ```python
 # Author: Jaime Fernández del Río
 
-C = np.bincount([1,1,2,3,4,4,6])
+C = np.bincount([1, 1, 2, 3, 4, 4, 6])
 A = np.repeat(np.arange(len(C)), C)
 print(A)
 ```
@@ -815,15 +839,16 @@ print(A)
 ```python
 # Author: Jaime Fernández del Río
 
-def moving_average(a, n=3) :
-    ret = np.cumsum(a, dtype=float)
-    ret[n:] = ret[n:] - ret[:-n]
-    return ret[n - 1:] / n
+def moving_average(a, n=3):
+  ret = np.cumsum(a, dtype=float)
+  ret[n:] = ret[n:] - ret[:-n]
+  return ret[n - 1:] / n
+
 Z = np.arange(20)
 print(moving_average(Z, n=3))
 ```
 
-#### 76. Consider a one-dimensional array Z, build a two-dimensional array whose first row is (Z\[0\],Z\[1\],Z\[2\]) and each subsequent row is  shifted by 1 (last row should be (Z\[-3\],Z\[-2\],Z\[-1\]) (★★★)
+#### 76. Consider a one-dimensional array Z, build a two-dimensional array whose first row is (Z\[0\], Z\[1\], Z\[2\]) and each subsequent row is shifted by 1 (last row should be (Z\[-3\], Z\[-2\], Z\[-1\]) (★★★)
 
 
 ```python
@@ -831,9 +856,11 @@ print(moving_average(Z, n=3))
 from numpy.lib import stride_tricks
 
 def rolling(a, window):
-    shape = (a.size - window + 1, window)
-    strides = (a.itemsize, a.itemsize)
-    return stride_tricks.as_strided(a, shape=shape, strides=strides)
+  shape = (a.size - window + 1, window)
+  strides = (a.itemsize, a.itemsize)
+  return stride_tricks.as_strided(
+    a, shape=shape, strides=strides)
+
 Z = rolling(np.arange(10), 3)
 print(Z)
 ```
@@ -844,42 +871,45 @@ print(Z)
 ```python
 # Author: Nathaniel J. Smith
 
-Z = np.random.randint(0,2,100)
+Z = np.random.randint(0, 2, 100)
 np.logical_not(Z, out=Z)
 
-Z = np.random.uniform(-1.0,1.0,100)
+Z = np.random.uniform(-1.0, 1.0, 100)
 np.negative(Z, out=Z)
 ```
 
-#### 78. Consider 2 sets of points P0,P1 describing lines (2d) and a point p, how to compute distance from p to each line i  (P0\[i\],P1\[i\])? (★★★)
+#### 78. Consider 2 sets of points P0,P1 describing lines (2d) and a point p, how to compute distance from p to each line i  (P0\[i\], P1\[i\])? (★★★)
 
 
 ```python
 def distance(P0, P1, p):
-    T = P1 - P0
-    L = (T**2).sum(axis=1)
-    U = -((P0[:,0]-p[...,0])*T[:,0] + (P0[:,1]-p[...,1])*T[:,1]) / L
-    U = U.reshape(len(U),1)
-    D = P0 + U*T - p
-    return np.sqrt((D**2).sum(axis=1))
+  T = P1 - P0
+  L = (T**2).sum(axis=1)
+  U = -((P0[:, 0] - p[..., 0]) * T[:, 0] +
+        (P0[:, 1] - p[..., 1]) * T[:, 1]) / L
+  U = U.reshape(len(U), 1)
+  D = P0 + U * T - p
+  return np.sqrt((D**2).sum(axis=1))
 
-P0 = np.random.uniform(-10,10,(10,2))
-P1 = np.random.uniform(-10,10,(10,2))
-p  = np.random.uniform(-10,10,( 1,2))
+P0 = np.random.uniform(-10, 10, (10, 2))
+P1 = np.random.uniform(-10, 10, (10, 2))
+p = np.random.uniform(-10, 10, (1, 2))
 print(distance(P0, P1, p))
 ```
 
-#### 79. Consider 2 sets of points P0,P1 describing lines (2d) and a set of points P, how to compute distance from each point j (P\[j\]) to each line i (P0\[i\],P1\[i\])? (★★★)
+#### 79. Consider 2 sets of points P0,P1 describing lines (2d) and a set of points P, how to compute distance from each point j (P\[j\]) to each line i (P0\[i\], P1\[i\])? (★★★)
 
 
 ```python
 # Author: Italmassov Kuanysh
 
-# based on distance function from previous question
-P0 = np.random.uniform(-10, 10, (10,2))
-P1 = np.random.uniform(-10,10,(10,2))
-p = np.random.uniform(-10, 10, (10,2))
-print(np.array([distance(P0,P1,p_i) for p_i in p]))
+# based on distance function
+# from previous question
+P0 = np.random.uniform(-10, 10, (10, 2))
+P1 = np.random.uniform(-10, 10, (10, 2))
+p = np.random.uniform(-10, 10, (10, 2))
+print(np.array(
+  [distance(P0, P1, p_i) for p_i in p]))
 ```
 
 #### 80. Consider an arbitrary array, write a function that extract a subpart with a fixed shape and centered on a given element (pad with a `fill` value when necessary) (★★★)
@@ -888,41 +918,45 @@ print(np.array([distance(P0,P1,p_i) for p_i in p]))
 ```python
 # Author: Nicolas Rougier
 
-Z = np.random.randint(0,10,(10,10))
-shape = (5,5)
-fill  = 0
-position = (1,1)
+Z = np.random.randint(0, 10, (10, 10))
+shape = (5, 5)
+fill = 0
+position = (1, 1)
 
-R = np.ones(shape, dtype=Z.dtype)*fill
-P  = np.array(list(position)).astype(int)
+R = np.ones(shape, dtype=Z.dtype) * fill
+P = np.array(list(position)).astype(int)
 Rs = np.array(list(R.shape)).astype(int)
 Zs = np.array(list(Z.shape)).astype(int)
 
-R_start = np.zeros((len(shape),)).astype(int)
-R_stop  = np.array(list(shape)).astype(int)
-Z_start = (P-Rs//2)
-Z_stop  = (P+Rs//2)+Rs%2
+R_start = np.zeros((len(shape), )).astype(int)
+R_stop = np.array(list(shape)).astype(int)
+Z_start = (P - Rs // 2)
+Z_stop = (P + Rs // 2) + Rs % 2
 
-R_start = (R_start - np.minimum(Z_start,0)).tolist()
-Z_start = (np.maximum(Z_start,0)).tolist()
-R_stop = np.maximum(R_start, (R_stop - np.maximum(Z_stop-Zs,0))).tolist()
-Z_stop = (np.minimum(Z_stop,Zs)).tolist()
+R_start = (R_start - np.minimum(Z_start, 0)).tolist()
+Z_start = (np.maximum(Z_start, 0)).tolist()
+R_stop = np.maximum(
+  R_start, (R_stop - np.maximum(Z_stop - Zs, 0))
+).tolist()
+Z_stop = (np.minimum(Z_stop, Zs)).tolist()
 
-r = [slice(start,stop) for start,stop in zip(R_start,R_stop)]
-z = [slice(start,stop) for start,stop in zip(Z_start,Z_stop)]
+r = [slice(start, stop)
+  for start, stop in zip(R_start, R_stop)]
+z = [slice(start, stop)
+  for start, stop in zip(Z_start, Z_stop)]
 R[r] = Z[z]
 print(Z)
 print(R)
 ```
 
-#### 81. Consider an array Z = \[1,2,3,4,5,6,7,8,9,10,11,12,13,14\], how to generate an array R = \[\[1,2,3,4\], \[2,3,4,5\], \[3,4,5,6\], ..., \[11,12,13,14\]\]? (★★★)
+#### 81. Consider an array Z = \[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14\], how to generate an array R = \[\[1, 2, 3, 4\], \[2, 3, 4, 5\], \[3, 4, 5, 6\], ..., \[11, 12, 13, 14\]\]? (★★★)
 
 
 ```python
 # Author: Stefan van der Walt
 
-Z = np.arange(1,15,dtype=np.uint32)
-R = stride_tricks.as_strided(Z,(11,4),(4,4))
+Z = np.arange(1, 15, dtype=np.uint32)
+R = stride_tricks.as_strided(Z, (11, 4), (4, 4))
 print(R)
 ```
 
@@ -932,8 +966,11 @@ print(R)
 ```python
 # Author: Stefan van der Walt
 
-Z = np.random.uniform(0,1,(10,10))
-U, S, V = np.linalg.svd(Z) # Singular Value Decomposition
+Z = np.random.uniform(0, 1, (10, 10))
+
+# Singular Value Decomposition
+U, S, V = np.linalg.svd(Z)
+
 rank = np.sum(S > 1e-10)
 print(rank)
 ```
@@ -942,7 +979,7 @@ print(rank)
 
 
 ```python
-Z = np.random.randint(0,10,50)
+Z = np.random.randint(0, 10, 50)
 print(np.bincount(Z).argmax())
 ```
 
@@ -952,52 +989,58 @@ print(np.bincount(Z).argmax())
 ```python
 # Author: Chris Barker
 
-Z = np.random.randint(0,5,(10,10))
+Z = np.random.randint(0, 5, (10, 10))
 n = 3
-i = 1 + (Z.shape[0]-3)
-j = 1 + (Z.shape[1]-3)
-C = stride_tricks.as_strided(Z, shape=(i, j, n, n), strides=Z.strides + Z.strides)
+i = 1 + (Z.shape[0] - 3)
+j = 1 + (Z.shape[1] - 3)
+C = stride_tricks.as_strided(
+  Z,
+  shape=(i, j, n, n),
+  strides=Z.strides + Z.strides)
 print(C)
 ```
 
-#### 85. Create a 2D array subclass such that Z\[i,j\] == Z\[j,i\] (★★★)
+#### 85. Create a 2D array subclass such that Z\[i, j\] == Z\[j, i\] (★★★)
 
 
 ```python
 # Author: Eric O. Lebigot
-# Note: only works for 2d array and value setting using indices
+# Note: only works for 2d array and value setting
+#       using indices
 
 class Symetric(np.ndarray):
-    def __setitem__(self, index, value):
-        i,j = index
-        super(Symetric, self).__setitem__((i,j), value)
-        super(Symetric, self).__setitem__((j,i), value)
+  def __setitem__(self, index, value):
+    i, j = index
+    super(Symetric, self).__setitem__((i, j), value)
+    super(Symetric, self).__setitem__((j, i), value)
 
 def symetric(Z):
-    return np.asarray(Z + Z.T - np.diag(Z.diagonal())).view(Symetric)
+  return np.asarray(Z + Z.T - np.diag(Z.diagonal())
+                    ).view(Symetric)
 
-S = symetric(np.random.randint(0,10,(5,5)))
-S[2,3] = 42
+S = symetric(np.random.randint(0, 10, (5, 5)))
+S[2, 3] = 42
 print(S)
 ```
 
-#### 86. Consider a set of p matrices wich shape (n,n) and a set of p vectors with shape (n,1). How to compute the sum of of the p matrix products at once? (result has shape (n,1)) (★★★)
+#### 86. Consider a set of p matrices wich shape (n, n) and a set of p vectors with shape (n, 1). How to compute the sum of of the p matrix products at once? (result has shape (n, 1)) (★★★)
 
 
 ```python
 # Author: Stefan van der Walt
 
 p, n = 10, 20
-M = np.ones((p,n,n))
-V = np.ones((p,n,1))
+M = np.ones((p, n, n))
+V = np.ones((p, n, 1))
 S = np.tensordot(M, V, axes=[[0, 2], [0, 1]])
 print(S)
 
 # It works, because:
-# M is (p,n,n)
-# V is (p,n,1)
-# Thus, summing over the paired axes 0 and 0 (of M and V independently),
-# and 2 and 1, to remain with a (n,1) vector.
+# M is (p, n, n)
+# V is (p, n, 1)
+# Thus, summing over the paired axes 0 and 0
+# (of M and V independently),
+# and 2 and 1, to remain with a (n, 1) vector.
 ```
 
 #### 87. Consider a 16x16 array, how to get the block-sum (block size is 4x4)? (★★★)
@@ -1006,10 +1049,12 @@ print(S)
 ```python
 # Author: Robert Kern
 
-Z = np.ones((16,16))
+Z = np.ones((16, 16))
 k = 4
-S = np.add.reduceat(np.add.reduceat(Z, np.arange(0, Z.shape[0], k), axis=0),
-                                       np.arange(0, Z.shape[1], k), axis=1)
+S = np.add.reduceat(
+  np.add.reduceat(
+    Z, np.arange(0, Z.shape[0], k), axis=0),
+       np.arange(0, Z.shape[1], k), axis=1)
 print(S)
 ```
 
@@ -1020,19 +1065,20 @@ print(S)
 # Author: Nicolas Rougier
 
 def iterate(Z):
-    # Count neighbours
-    N = (Z[0:-2,0:-2] + Z[0:-2,1:-1] + Z[0:-2,2:] +
-         Z[1:-1,0:-2]                + Z[1:-1,2:] +
-         Z[2:  ,0:-2] + Z[2:  ,1:-1] + Z[2:  ,2:])
+  # Count neighbours
+  N = (
+    Z[0:-2, 0:-2] + Z[0:-2, 1:-1] + Z[0:-2, 2:] +
+    Z[1:-1, 0:-2] +                 Z[1:-1, 2:] +
+    Z[2:,   0:-2] + Z[2:,   1:-1] + Z[2:,   2:])
 
-    # Apply rules
-    birth = (N==3) & (Z[1:-1,1:-1]==0)
-    survive = ((N==2) | (N==3)) & (Z[1:-1,1:-1]==1)
-    Z[...] = 0
-    Z[1:-1,1:-1][birth | survive] = 1
-    return Z
+  # Apply rules
+  birth = (N == 3) & (Z[1:-1, 1:-1] == 0)
+  survive = ((N == 2) | (N == 3)) & (Z[1:-1, 1:-1] == 1)
+  Z[...] = 0
+  Z[1:-1, 1:-1][birth | survive] = 1
+  return Z
 
-Z = np.random.randint(0,2,(50,50))
+Z = np.random.randint(0, 2, (50, 50))
 for i in range(100): Z = iterate(Z)
 print(Z)
 ```
@@ -1046,10 +1092,10 @@ np.random.shuffle(Z)
 n = 5
 
 # Slow
-print (Z[np.argsort(Z)[-n:]])
+print(Z[np.argsort(Z)[-n:]])
 
 # Fast
-print (Z[np.argpartition(-Z,n)[:n]])
+print(Z[np.argpartition(-Z, n)[:n]])
 ```
 
 #### 90. Given an arbitrary number of vectors, build the cartesian product (every combinations of every item) (★★★)
@@ -1059,18 +1105,18 @@ print (Z[np.argpartition(-Z,n)[:n]])
 # Author: Stefan Van der Walt
 
 def cartesian(arrays):
-    arrays = [np.asarray(a) for a in arrays]
-    shape = (len(x) for x in arrays)
+  arrays = [np.asarray(a) for a in arrays]
+  shape = (len(x) for x in arrays)
 
-    ix = np.indices(shape, dtype=int)
-    ix = ix.reshape(len(arrays), -1).T
+  ix = np.indices(shape, dtype=int)
+  ix = ix.reshape(len(arrays), -1).T
 
-    for n, arr in enumerate(arrays):
-        ix[:, n] = arrays[n][ix[:, n]]
+  for n, arr in enumerate(arrays):
+    ix[:, n] = arrays[n][ix[:, n]]
 
-    return ix
+  return ix
 
-print (cartesian(([1, 2, 3], [4, 5], [6, 7])))
+print(cartesian(([1, 2, 3], [4, 5], [6, 7])))
 ```
 
 #### 91. How to create a record array from a regular array? (★★★)
@@ -1079,9 +1125,10 @@ print (cartesian(([1, 2, 3], [4, 5], [6, 7])))
 ```python
 Z = np.array([("Hello", 2.5, 3),
               ("World", 3.6, 2)])
-R = np.core.records.fromarrays(Z.T, 
-                               names='col1, col2, col3',
-                               formats = 'S8, f8, i8')
+R = np.core.records.fromarrays(
+             Z.T,
+             names='col1, col2, col3',
+             formats = 'S8, f8, i8')
 print(R)
 ```
 
@@ -1093,39 +1140,41 @@ print(R)
 
 x = np.random.rand(5e7)
 
-%timeit np.power(x,3)
-%timeit x*x*x
-%timeit np.einsum('i,i,i->i',x,x,x)
+%timeit np.power(x, 3)
+%timeit x * x * x
+%timeit np.einsum('i,i,i->i', x, x, x)
 ```
 
-#### 93. Consider two arrays A and B of shape (8,3) and (2,2). How to find rows of A that contain elements of each row of B regardless of the order of the elements in B? (★★★)
+#### 93. Consider two arrays A and B of shape (8, 3) and (2, 2). How to find rows of A that contain elements of each row of B regardless of the order of the elements in B? (★★★)
 
 
 ```python
 # Author: Gabe Schwartz
 
-A = np.random.randint(0,5,(8,3))
-B = np.random.randint(0,5,(2,2))
+A = np.random.randint(0, 5, (8, 3))
+B = np.random.randint(0, 5, (2, 2))
 
 C = (A[..., np.newaxis, np.newaxis] == B)
-rows = np.where(C.any((3,1)).all(1))[0]
+rows = np.where(C.any((3, 1)).all(1))[0]
 print(rows)
 ```
 
-#### 94. Considering a 10x3 matrix, extract rows with unequal values (e.g. \[2,2,3\]) (★★★)
+#### 94. Considering a 10x3 matrix, extract rows with unequal values (e.g. \[2, 2, 3\]) (★★★)
 
 
 ```python
 # Author: Robert Kern
 
-Z = np.random.randint(0,5,(10,3))
+Z = np.random.randint(0, 5, (10, 3))
 print(Z)
-# solution for arrays of all dtypes (including string arrays and record arrays)
-E = np.all(Z[:,1:] == Z[:,:-1], axis=1)
+# solution for arrays of all dtypes
+# (including string arrays and record arrays)
+E = np.all(Z[:, 1:] == Z[:, :-1], axis=1)
 U = Z[~E]
 print(U)
-# soluiton for numerical arrays only, will work for any number of columns in Z
-U = Z[Z.max(axis=1) != Z.min(axis=1),:]
+# solution for numerical arrays only,
+# will work for any number of columns in Z
+U = Z[Z.max(axis=1) != Z.min(axis=1), :]
 print(U)
 ```
 
@@ -1136,12 +1185,14 @@ print(U)
 # Author: Warren Weckesser
 
 I = np.array([0, 1, 2, 3, 15, 16, 32, 64, 128])
-B = ((I.reshape(-1,1) & (2**np.arange(8))) != 0).astype(int)
-print(B[:,::-1])
+B = ((I.reshape(-1, 1) &
+      (2**np.arange(8))) != 0).astype(int)
+print(B[:, ::-1])
 
 # Author: Daniel T. McDonald
 
-I = np.array([0, 1, 2, 3, 15, 16, 32, 64, 128], dtype=np.uint8)
+I = np.array([0, 1, 2, 3, 15, 16, 32, 64, 128],
+             dtype=np.uint8)
 print(np.unpackbits(I[:, np.newaxis], axis=1))
 ```
 
@@ -1151,8 +1202,10 @@ print(np.unpackbits(I[:, np.newaxis], axis=1))
 ```python
 # Author: Jaime Fernández del Río
 
-Z = np.random.randint(0,2,(6,3))
-T = np.ascontiguousarray(Z).view(np.dtype((np.void, Z.dtype.itemsize * Z.shape[1])))
+Z = np.random.randint(0, 2, (6, 3))
+T = np.ascontiguousarray(Z).view(
+  np.dtype(
+    (np.void, Z.dtype.itemsize * Z.shape[1])))
 _, idx = np.unique(T, return_index=True)
 uZ = Z[idx]
 print(uZ)
@@ -1163,33 +1216,38 @@ print(uZ)
 
 ```python
 # Author: Alex Riley
-# Make sure to read: http://ajcr.net/Basic-guide-to-einsum/
+# Make sure to read:
+# http://ajcr.net/Basic-guide-to-einsum/
 
-A = np.random.uniform(0,1,10)
-B = np.random.uniform(0,1,10)
+A = np.random.uniform(0, 1, 10)
+B = np.random.uniform(0, 1, 10)
 
-np.einsum('i->', A)       # np.sum(A)
-np.einsum('i,i->i', A, B) # A * B
-np.einsum('i,i', A, B)    # np.inner(A, B)
-np.einsum('i,j->ij', A, B)    # np.outer(A, B)
+np.einsum('i->', A)        # np.sum(A)
+np.einsum('i,i->i', A, B)  # A * B
+np.einsum('i,i', A, B)     # np.inner(A, B)
+np.einsum('i,j->ij', A, B) # np.outer(A, B)
 ```
 
-#### 98. Considering a path described by two vectors (X,Y), how to sample it using equidistant samples (★★★)?
+#### 98. Considering a path described by two vectors (X, Y), how to sample it using equidistant samples (★★★)?
 
 
 ```python
 # Author: Bas Swinckels
 
-phi = np.arange(0, 10*np.pi, 0.1)
+phi = np.arange(0, 10 * np.pi, 0.1)
 a = 1
-x = a*phi*np.cos(phi)
-y = a*phi*np.sin(phi)
+x = a * phi * np.cos(phi)
+y = a * phi * np.sin(phi)
 
-dr = (np.diff(x)**2 + np.diff(y)**2)**.5 # segment lengths
+# segment lengths
+dr = (np.diff(x)**2 + np.diff(y)**2)**.5
 r = np.zeros_like(x)
-r[1:] = np.cumsum(dr)                # integrate path
-r_int = np.linspace(0, r.max(), 200) # regular spaced path
-x_int = np.interp(r_int, r, x)       # integrate path
+# integrate path
+r[1:] = np.cumsum(dr)
+# regular spaced path
+r_int = np.linspace(0, r.max(), 200)
+# integrate path
+x_int = np.interp(r_int, r, x)
 y_int = np.interp(r_int, r, y)
 ```
 
@@ -1203,7 +1261,8 @@ X = np.asarray([[1.0, 0.0, 3.0, 8.0],
                 [2.0, 0.0, 1.0, 1.0],
                 [1.5, 2.5, 1.0, 0.0]])
 n = 4
-M = np.logical_and.reduce(np.mod(X, 1) == 0, axis=-1)
+M = np.logical_and.reduce(
+  np.mod(X, 1) == 0, axis=-1)
 M &= (X.sum(axis=-1) == n)
 print(X[M])
 ```


### PR DESCRIPTION
This PR mainly wraps comment lines manually, shortens code lines and applies some readability improvements mostly as suggested by `yapf`. This helps generate a PDF version with index cards like in my fork. But as usual in such cases, the result is sometimes a bit of a compromise.