### PR TITLE
Fix typo in Excercise no.23,42.

### DIFF
--- a/100 Numpy exercises no solution.ipynb
+++ b/100 Numpy exercises no solution.ipynb
@@ -381,7 +381,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 23. Create a custom dtype that describes a color as four unisgned bytes (RGBA) (★☆☆)"
+    "#### 23. Create a custom dtype that describes a color as four unsigned bytes (RGBA) (★☆☆)"
    ]
   },
   {
@@ -732,7 +732,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 42. Consider two random array A anb B, check if they are equal (★★☆)"
+    "#### 42. Consider two random array A and B, check if they are equal (★★☆)"
    ]
   },
   {

--- a/100 Numpy exercises no solution.md
+++ b/100 Numpy exercises no solution.md
@@ -105,7 +105,7 @@ np.nan - np.nan
 
 
 
-#### 23. Create a custom dtype that describes a color as four unisgned bytes (RGBA) (★☆☆)
+#### 23. Create a custom dtype that describes a color as four unsigned bytes (RGBA) (★☆☆)
 
 
 
@@ -204,7 +204,7 @@ np.sqrt(-1) == np.emath.sqrt(-1)
 
 
 
-#### 42. Consider two random array A anb B, check if they are equal (★★☆)
+#### 42. Consider two random array A and B, check if they are equal (★★☆)
 
 
 

--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -444,7 +444,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 23. Create a custom dtype that describes a color as four unisgned bytes (RGBA) (★☆☆)"
+    "#### 23. Create a custom dtype that describes a color as four unsigned bytes (RGBA) (★☆☆)"
    ]
   },
   {
@@ -850,7 +850,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 42. Consider two random array A anb B, check if they are equal (★★☆)"
+    "#### 42. Consider two random array A and B, check if they are equal (★★☆)"
    ]
   },
   {

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -192,7 +192,7 @@ Z = (Z - Zmin)/(Zmax - Zmin)
 print(Z)
 ```
 
-#### 23. Create a custom dtype that describes a color as four unisgned bytes (RGBA) (★☆☆)
+#### 23. Create a custom dtype that describes a color as four unsigned bytes (RGBA) (★☆☆)
 
 
 ```python
@@ -392,7 +392,7 @@ Z = np.arange(10)
 np.add.reduce(Z)
 ```
 
-#### 42. Consider two random array A anb B, check if they are equal (★★☆)
+#### 42. Consider two random array A and B, check if they are equal (★★☆)
 
 
 ```python


### PR DESCRIPTION
I have edited the typo in exercise no 23 , 42 

"Consider two random array A **anb** B, check if they are equal (★★☆)"

instead of **and** it was typed as **anb**

AND

23. Create a custom dtype that describes a color as four **unisgned** bytes (RGBA) (★☆☆)

**unisgned** --> **unsigned**
