### PR TITLE
solution to 50 only works for a vector

### DIFF
--- a/100 Numpy exercises no solution.ipynb
+++ b/100 Numpy exercises no solution.ipynb
@@ -860,7 +860,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 50. How to find the closest value (to a given scalar) in an array? (★★☆)"
+    "#### 50. How to find the closest value (to a given scalar) in a vector? (★★☆)"
    ]
   },
   {

--- a/100 Numpy exercises no solution.md
+++ b/100 Numpy exercises no solution.md
@@ -236,7 +236,7 @@ np.sqrt(-1) == np.emath.sqrt(-1)
 
 
 
-#### 50. How to find the closest value (to a given scalar) in an array? (★★☆)
+#### 50. How to find the closest value (to a given scalar) in a vector? (★★☆)
 
 
 

--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -1028,7 +1028,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 50. How to find the closest value (to a given scalar) in an array? (★★☆)"
+    "#### 50. How to find the closest value (to a given scalar) in a vector? (★★☆)"
    ]
   },
   {

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -482,7 +482,7 @@ Z = np.zeros((16,16))
 print(Z)
 ```
 
-#### 50. How to find the closest value (to a given scalar) in an array? (★★☆)
+#### 50. How to find the closest value (to a given scalar) in a vector? (★★☆)
 
 
 ```python


### PR DESCRIPTION
If a 2D array (`Z`) instead of a 1D array is constructed, the solution to 50 will not work, contradicting the question 

```
Z = np.random.randint(0,100,(5,5))
Z[0,:] = 200
v = np.random.uniform(0,100)
index = (np.abs(Z-v)).argmin()
print(Z[index])
```

Alternatively, the solution could be changed to

```print(Z.flatten()[index])```

