### PR TITLE
Change "exercices" to "exercises"

### DIFF
--- a/100 Numpy exercises no solution.ipynb
+++ b/100 Numpy exercises no solution.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# 100 numpy exercises\n",
     "\n",
-    "This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercices for those who teach.\n",
+    "This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercises for those who teach.\n",
     "\n",
     "\n",
     "If you find an error or think you've a better way to solve some of them, feel free to open an issue at <https://github.com/rougier/numpy-100>"

--- a/100 Numpy exercises no solution.md
+++ b/100 Numpy exercises no solution.md
@@ -4,7 +4,7 @@
 This is a collection of exercises that have been collected in the numpy mailing
 list, on stack overflow and in the numpy documentation. I've also created some
 to reach the 100 limit. The goal of this collection is to offer a quick
-reference for both old and new users but also to provide a set of exercices for
+reference for both old and new users but also to provide a set of exercises for
 those who teach.
 
 If you find an error or think you've a better way to solve some of them, feel

--- a/100 Numpy exercises with hint.ipynb
+++ b/100 Numpy exercises with hint.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# 100 numpy exercises with hint\n",
     "\n",
-    "This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercices for those who teach.\n",
+    "This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercises for those who teach.\n",
     "\n",
     "\n",
     "If you find an error or think you've a better way to solve some of them, feel free to open an issue at <https://github.com/rougier/numpy-100>"

--- a/100 Numpy exercises with hint.md
+++ b/100 Numpy exercises with hint.md
@@ -4,7 +4,7 @@
 This is a collection of exercises that have been collected in the numpy mailing
 list, on stack overflow and in the numpy documentation. I've also created some
 to reach the 100 limit. The goal of this collection is to offer a quick
-reference for both old and new users but also to provide a set of exercices for
+reference for both old and new users but also to provide a set of exercises for
 those who teach.
 
 If you find an error or think you've a better way to solve some of them, feel

--- a/100 Numpy exercises.ipynb
+++ b/100 Numpy exercises.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# 100 numpy exercises\n",
     "\n",
-    "This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercices for those who teach.\n",
+    "This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercises for those who teach.\n",
     "\n",
     "\n",
     "If you find an error or think you've a better way to solve some of them, feel free to open an issue at <https://github.com/rougier/numpy-100>"

--- a/100 Numpy exercises.md
+++ b/100 Numpy exercises.md
@@ -1,7 +1,7 @@
 
 # 100 numpy exercises
 
-This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercices for those who teach.
+This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow and in the numpy documentation. The goal of this collection is to offer a quick reference for both old and new users but also to provide a set of exercises for those who teach.
 
 
 If you find an error or think you've a better way to solve some of them, feel free to open an issue at <https://github.com/rougier/numpy-100>


### PR DESCRIPTION
I think that "exercices" is a misspelling of "exercises".
This pull request fixes above issue.