### PR TITLE
Fix bug in solution 53 .ipynb & .md files

### DIFF
--- a/100_Numpy_exercises.ipynb
+++ b/100_Numpy_exercises.ipynb
@@ -1017,9 +1017,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Z = np.arange(10, dtype=np.float32)\n",
-    "Z = Z.astype(np.int32, copy=False)\n",
-    "print(Z)"
+    "# Thanks Vikas (https://stackoverflow.com/a/10622758/5989906) \n",
+    "# & unutbu (https://stackoverflow.com/a/4396247/5989906)\n",
+    "Z = (np.random.rand(10)*100).astype(np.float32)\n",
+    "Y = Z.view(np.int32)\n",
+    "Y[:] = Z\n",
+    "print(Y)"
    ]
   },
   {
@@ -2165,7 +2168,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/100_Numpy_exercises.md
+++ b/100_Numpy_exercises.md
@@ -527,9 +527,12 @@ print(D)
 
 
 ```python
-Z = np.arange(10, dtype=np.float32)
-Z = Z.astype(np.int32, copy=False)
-print(Z)
+# Thanks Vikas (https://stackoverflow.com/a/10622758/5989906) 
+# & unutbu (https://stackoverflow.com/a/4396247/5989906)
+Z = (np.random.rand(10)*100).astype(np.float32)
+Y = Z.view(np.int32)
+Y[:] = Z
+print(Y)
 ```
 
 #### 54. How to read the following file? (★★☆)

--- a/100_Numpy_exercises_with_hint.ipynb
+++ b/100_Numpy_exercises_with_hint.ipynb
@@ -866,7 +866,7 @@
    "metadata": {},
    "source": [
     "#### 53. How to convert a float (32 bits) array into an integer (32 bits) in place? \n",
-    "(**hint**: astype(copy=False))"
+    "(**hint**: view and [:] = )"
    ]
   },
   {
@@ -1611,7 +1611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/100_Numpy_exercises_with_hint.md
+++ b/100_Numpy_exercises_with_hint.md
@@ -351,7 +351,7 @@ np.sqrt(-1) == np.emath.sqrt(-1)
 
 #### 53. How to convert a float (32 bits) array into an integer (32 bits) in place? 
 
-(**hint**: astype(copy=False))
+(**hint**: view and [:] = )
 
 
 


### PR DESCRIPTION
According to [this answer](https://stackoverflow.com/a/10622758/5989906), `astype(copy=False)` will still do a copy operation if the type differs. 
The [newest solution featured in this post](https://stackoverflow.com/a/4396247/5989906) might be better, hence this pull requests replaces the old one by the new one.