### PR TITLE
fix issue #79

### DIFF
--- a/100_Numpy_exercises.ipynb
+++ b/100_Numpy_exercises.ipynb
@@ -564,7 +564,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 36. Extract the integer part of a random array using 5 different methods (★★☆)"
+    "#### 36. Extract the integer part of a random array of positive numbers using 4 different methods (★★☆)"
    ]
   },
   {
@@ -1478,5 +1478,5 @@
  ],
  "metadata": {},
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/100_Numpy_exercises.md
+++ b/100_Numpy_exercises.md
@@ -113,7 +113,7 @@ np.sqrt(-1) == np.emath.sqrt(-1)
 
 #### 35. How to compute ((A+B)*(-A/2)) in place (without copy)? (★★☆)
 
-#### 36. Extract the integer part of a random array using 5 different methods (★★☆)
+#### 36. Extract the integer part of a random array of positive numbers using 4 different methods (★★☆)
 
 #### 37. Create a 5x5 matrix with row values ranging from 0 to 4 (★★☆)
 

--- a/100_Numpy_exercises_with_hints.md
+++ b/100_Numpy_exercises_with_hints.md
@@ -113,8 +113,8 @@ np.sqrt(-1) == np.emath.sqrt(-1)
 `hint: np.arange(dtype=datetime64['D'])`
 #### 35. How to compute ((A+B)*(-A/2)) in place (without copy)? (★★☆)
 `hint: np.add(out=), np.negative(out=), np.multiply(out=), np.divide(out=)`
-#### 36. Extract the integer part of a random array using 5 different methods (★★☆)
-`hint: %, np.floor, np.ceil, astype, np.trunc`
+#### 36. Extract the integer part of a random array of positive numbers using 4 different methods (★★☆)
+`hint: %, np.floor, astype, np.trunc`
 #### 37. Create a 5x5 matrix with row values ranging from 0 to 4 (★★☆)
 `hint: np.arange`
 #### 38. Consider a generator function that generates 10 integers and use it to build an array (★☆☆)

--- a/100_Numpy_exercises_with_hints_with_solutions.md
+++ b/100_Numpy_exercises_with_hints_with_solutions.md
@@ -331,15 +331,14 @@ np.divide(A,2,out=A)
 np.negative(A,out=A)
 np.multiply(A,B,out=A)
 ```
-#### 36. Extract the integer part of a random array using 5 different methods (★★☆)
-`hint: %, np.floor, np.ceil, astype, np.trunc`
+#### 36. Extract the integer part of a random array of positive numbers using 4 different methods (★★☆)
+`hint: %, np.floor, astype, np.trunc`
 
 ```python
 Z = np.random.uniform(0,10,10)
 
 print (Z - Z%1)
 print (np.floor(Z))
-print (np.ceil(Z)-1)
 print (Z.astype(int))
 print (np.trunc(Z))
 ```
@@ -463,7 +462,8 @@ for dtype in [np.float32, np.float64]:
 `hint: np.set_printoptions`
 
 ```python
-np.set_printoptions(threshold=np.nan)
+import sys
+np.set_printoptions(threshold=sys.maxsize)
 Z = np.zeros((16,16))
 print(Z)
 ```

--- a/100_Numpy_exercises_with_solutions.md
+++ b/100_Numpy_exercises_with_solutions.md
@@ -211,7 +211,7 @@ print(Z)
 # Author: Evgeni Burovski
 
 Z = np.arange(11)
-Z[(3 < Z) & (Z < 8)] *= -1
+Z[(3 < Z) & (Z <= 8)] *= -1
 print(Z)
 ```
 #### 26. What is the output of the following script? (★☆☆)
@@ -331,7 +331,7 @@ np.divide(A,2,out=A)
 np.negative(A,out=A)
 np.multiply(A,B,out=A)
 ```
-#### 36. Extract the integer part of a random array using 5 different methods (★★☆)
+#### 36. Extract the integer part of a random array of positive numbers using 4 different methods (★★☆)
 
 
 ```python
@@ -339,7 +339,6 @@ Z = np.random.uniform(0,10,10)
 
 print (Z - Z%1)
 print (np.floor(Z))
-print (np.ceil(Z)-1)
 print (Z.astype(int))
 print (np.trunc(Z))
 ```
@@ -463,7 +462,8 @@ for dtype in [np.float32, np.float64]:
 
 
 ```python
-np.set_printoptions(threshold=np.nan)
+import sys
+np.set_printoptions(threshold=sys.maxsize)
 Z = np.zeros((16,16))
 print(Z)
 ```

--- a/100_Numpy_random.ipynb
+++ b/100_Numpy_random.ipynb
@@ -51,5 +51,5 @@
  ],
  "metadata": {},
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -595,7 +595,8 @@ How to print all the values of an array? (★★☆)
 hint: np.set_printoptions
 
 < a49
-np.set_printoptions(threshold=np.nan)
+import sys
+np.set_printoptions(threshold=sys.maxsize)
 Z = np.zeros((16,16))
 print(Z)
 


### PR DESCRIPTION
Setting `np.set_printoption`'s `threshold` param to `np.nan` is no longer allowed and should use `sys.maxsize` instead:

> /anaconda3/lib/python3.7/site-packages/numpy/core/arrayprint.py in _make_options_dict(precision, threshold, edgeitems, linewidth, suppress, nanstr, infstr, sign, formatter, floatmode, legacy)
     91         # forbid the bad threshold arg suggested by stack overflow, gh-12351
     92         if not isinstance(threshold, numbers.Number) or np.isnan(threshold):
---> 93             raise ValueError("threshold must be numeric and non-NAN, try "
     94                              "sys.maxsize for untruncated representation")
     95     return options
>
> ValueError: threshold must be numeric and non-NAN, try sys.maxsize for untruncated representation