### PR TITLE
fix deprecated type definition.

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -248,10 +248,10 @@ Create a custom dtype that describes a color as four unsigned bytes (RGBA) (★�
 hint: np.dtype
 
 < a23
-color = np.dtype([("r", np.ubyte, 1),
-                  ("g", np.ubyte, 1),
-                  ("b", np.ubyte, 1),
-                  ("a", np.ubyte, 1)])
+color = np.dtype([("r", np.ubyte),
+                  ("g", np.ubyte),
+                  ("b", np.ubyte),
+                  ("a", np.ubyte)])
 
 < q24
 Multiply a 5x3 matrix by a 3x2 matrix (real matrix product) (★☆☆)


### PR DESCRIPTION
Original answer triggered `c:\conda\envs\bigdata\lib\site-packages\ipykernel_launcher.py:5: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.`
New answer proposed per [Numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.dtype.html)