### PR TITLE
upd example in a49

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -604,7 +604,7 @@ hint: np.set_printoptions
 
 < a49
 np.set_printoptions(threshold=float("inf"))
-Z = np.zeros((16,16))
+Z = np.zeros((40,40))
 print(Z)
 
 < q50


### PR DESCRIPTION
with default `threshold=1000` [see Numpy code reference], (https://github.com/numpy/numpy/blob/551773f27ccc955ce24d15eae84eed924250c573/numpy/core/arrayprint.py#L107-L110) 16x16 is always printed OK. A larger np.array is needed to illustrate the difference. Anything with over 1000 elements would do.