### PR TITLE
alternative solution for Q.82

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -1148,7 +1148,7 @@ print(R)
 Compute a matrix rank (★★★)
 
 < h82
-hint: np.linalg.svd
+hint: np.linalg.svd, np.linalg.matrix_rank
 
 < a82
 # Author: Stefan van der Walt
@@ -1156,6 +1156,12 @@ hint: np.linalg.svd
 Z = np.random.uniform(0,1,(10,10))
 U, S, V = np.linalg.svd(Z) # Singular Value Decomposition
 rank = np.sum(S > 1e-10)
+print(rank)
+
+# alternative solution:
+# Author: Jeff Luo (@Jeff1999)
+
+rank = np.linalg.matrix_rank(Z)
 print(rank)
 
 < q83


### PR DESCRIPTION
`Q.82`: To calculate the rank of a matrix, I replace `np.linalg.svd` with `np.linalg.matrix_rank` which both use the SVD method. `np.linalg.matrix_rank` is handier and contains less code.