### PR TITLE
alternative solution for Q.83

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -1168,11 +1168,17 @@ print(rank)
 How to find the most frequent value in an array?
 
 < h83
-hint: np.bincount, argmax
+hint: np.bincount, argmax, np.unique
 
 < a83
 Z = np.random.randint(0,10,50)
 print(np.bincount(Z).argmax())
+
+# alternative solution:
+# Author: Jeff Luo (@Jeff1999)
+
+num, cnt = np.unique(Z, return_counts=True)
+print(num[cnt.argmax()])
 
 < q84
 Extract all the contiguous 3x3 blocks from a random 10x10 matrix (★★★)


### PR DESCRIPTION
`Q.83`: The `np.bincount` only counts **non-negative ints** according to its docs, which is not very useful in the dirty dataset. It can be optimized with `np.unique(data, return_counts=True)`, which returns the unique values and corresponding count.