### PR TITLE
Remove incorrect alternative solution q19

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -211,12 +211,6 @@ Z[1::2,::2] = 1
 Z[::2,1::2] = 1
 print(Z)
 
-# Alternative solution: Using reshaping
-arr = np.ones(64,dtype=int)
-arr[::2]=0
-arr = arr.reshape((8,8))
-print(arr)
-
 < q20
 Consider a (6,7,8) shape array, what is the index (x,y,z) of the 100th element? (★☆☆)
 


### PR DESCRIPTION
The reshape-based solution for q19 (#189) did only work for odd numbered squares, not even ones such as 8x8 squares:

```python
In [82]: arr = np.ones(64,dtype=int)
    ...: arr[::2]=0
    ...: arr = arr.reshape((8,8))
    ...: print(arr)
[[0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]
 [0 1 0 1 0 1 0 1]]
 ```