### PR TITLE
Update solution to Q.39

### DIFF
--- a/100_Numpy_exercises_with_hints_with_solutions.md
+++ b/100_Numpy_exercises_with_hints_with_solutions.md
@@ -376,7 +376,7 @@ print(Z)
 `hint: np.linspace`
 
 ```python
-Z = np.linspace(0,1,11,endpoint=False)[1:]
+Z = np.linspace(0,1,10,endpoint=True)[1:-1]
 print(Z)
 ```
 #### 40. Create a random vector of size 10 and sort it (★★☆)

--- a/100_Numpy_exercises_with_solutions.md
+++ b/100_Numpy_exercises_with_solutions.md
@@ -376,7 +376,7 @@ print(Z)
 
 
 ```python
-Z = np.linspace(0,1,11,endpoint=False)[1:]
+Z = np.linspace(0,1,10,endpoint=True)[1:-1]
 print(Z)
 ```
 #### 40. Create a random vector of size 10 and sort it (★★☆)

--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -479,7 +479,7 @@ Create a vector of size 10 with values ranging from 0 to 1, both excluded (â˜…â˜
 hint: np.linspace
 
 < a39
-Z = np.linspace(0,1,11,endpoint=False)[1:]
+Z = np.linspace(0,1,10,endpoint=True)[1:-1]
 print(Z)
 
 < q40


### PR DESCRIPTION
As I mentioned in the following issue: https://github.com/rougier/numpy-100/issues/209

The solution is not correct for question 39. The question asks for a "vector of size 10 with values ranging from 0 to 1, both excluded". The provided solution generates a vector from 0 to 0.90909091.

This is because the flag `endpoint` is set to `false`: 
```
Z = np.linspace(0,1,11,endpoint=False)[1:]
```

The correct solution is:
```
Z = np.linspace(0,1,11,endpoint=True)[1:-1]
```

I can see in other PRs that the .mds are generated by the .ktx file. I've updated the .ktx, but I'm not sure if I need to remove the changes to the .md files.