### PR TITLE
feat: generator workflow post-merge

### DIFF
--- a/.github/workflows/generate_solutions_files.yml
+++ b/.github/workflows/generate_solutions_files.yml
@@ -1,0 +1,46 @@
+name: Generate Solutions Files
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - source/exercises100.ktx
+
+jobs:
+  generate_files:
+    runs-on: ubuntu-22.04 # Python 3.7 is not supported on latest Ubuntu
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip3 install -r requirements.txt
+
+      - name: Generate solutions files
+        run: python3 generators.py
+
+      - name: Set environment variables
+        run: echo "SHA_SHORT=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "solutions update from ${{ env.SHA_SHORT }}"
+          file_pattern: >
+            100_Numpy_exercises.ipynb
+            100_Numpy_random.ipynb
+            100_Numpy_exercises.md
+            100_Numpy_exercises_with_hints.md
+            100_Numpy_exercises_with_hints_with_solutions.md
+            100_Numpy_exercises_with_solutions.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-numpy==1.17.4
-pandas==0.25.3
-jupyter==1.0.0
-jupyterthemes==0.20.0
-mdutils==1.0.0
+numpy
+mdutils
+nbformat


### PR DESCRIPTION
Attempt https://github.com/rougier/numpy-100/issues/228#issuecomment-2664155327 at setting up a workflow that automatically generates solution files after merging a PR

#### expected/intended flow:

- contributor forks `rougier/numpy-100`  
- they create a new branch, update `source/exercises100.ktx`, and open a PR to `rougier/numpy-100:master`  
  - review → iterate → merge when ready  
- PR is merged into `rougier/numpy-100:master`, workflow kicks in, generating the required solution files  
- updated solutions are automatically committed back to `rougier/numpy-100:master`  

#### key choices:

- used [git auto commit](https://github.com/stefanzweifel/git-auto-commit-action) action to commit solutions files; a very concise overview [here](https://michaelheap.com/git-auto-commit/)
   - Triggered on push to master from changes to `source/exercises100.ktx`
   - Only looks for [uncommitted changes](https://github.com/stefanzweifel/git-auto-commit-action/blob/a6006229e0c9695d16a585acf619a3a9548b18f9/entrypoint.sh#L35C1-L38C2) specified in `file_pattern`, i.e., the `ipynb` and `md` files generated; no other files will be committed
- pinned to python 3.7 and ubuntu 22.04 to match `runtime.txt`
- commit message includes the short SHA

#### other considerations:

- I considered running this workflow in PRs instead of post-merge but opted for post-merge to **avoid permission complexities** due to GitHub’s security model and **keep PRs focused** on `exercises100.ktx` edits without cluttering them with generated files

- I wondered if there may be potential edge case errors with the generator script that might disrupt runs, but test runs suggest everything is working well, especially with package versions pinned in `requirements.txt`; if needed, future improvements could include adding a way to review the generated files before they go live
