### PR TITLE
Use default_rng() instead of np.random.random in Exercise #12

### DIFF
--- a/100_Numpy_exercises_with_hints_with_solutions.md
+++ b/100_Numpy_exercises_with_hints_with_solutions.md
@@ -96,6 +96,15 @@ print(Z)
 Z = np.random.random((3,3,3))
 print(Z)
 ```
+`hint: np.random.default_rng().random`
+```python
+# Author: KnightSnape
+
+rng = np.random.default_rng()
+Z = rng.random((3, 3, 3))
+print(Z)
+```
+
 #### 13. Create a 10x10 array with random values and find the minimum and maximum values (★☆☆)
 `hint: min, max`
 


### PR DESCRIPTION
## Summary

Replaced the use of `np.random.random` with the modern and recommended `default_rng().random` API in Exercise 12.

## Details

According to the [NumPy documentation](https://numpy.org/doc/stable/reference/random/index.html), the legacy `RandomState`-based API (`np.random.random`) is no longer recommended unless backwards compatibility is required.

The new Generator-based API (introduced in NumPy 1.17) offers better randomness, reproducibility, and future safety.

## Change

**Old solution (Line 96)**:
```python
Z = np.random.random((3,3,3))
print(Z)