### PR TITLE
Fix: updated markdown code to handle missing values and AttributeError: module 'numpy' has no attribute 'int' when using np.genfromtxt(closes #247)

### DIFF
--- a/100_Numpy_exercises_with_solutions.md
+++ b/100_Numpy_exercises_with_solutions.md
@@ -1,8 +1,12 @@
+
+
+
 # 100 numpy exercises
 
 This is a collection of exercises that have been collected in the numpy mailing list, on stack overflow
 and in the numpy documentation. The goal of this collection is to offer a quick reference for both old
 and new users but also to provide a set of exercises for those who teach.
+
 
 If you find an error or think you've a better way to solve some of them, feel
 free to open an issue at <https://github.com/rougier/numpy-100>.
@@ -10,25 +14,26 @@ File automatically generated. See the documentation to update questions/answers/
 
 #### 1. Import the numpy package under the name `np` (★☆☆)
 
+
 ```python
 import numpy as np
 ```
-
 #### 2. Print the numpy version and the configuration (★☆☆)
+
 
 ```python
 print(np.__version__)
 np.show_config()
 ```
-
 #### 3. Create a null vector of size 10 (★☆☆)
+
 
 ```python
 Z = np.zeros(10)
 print(Z)
 ```
-
 #### 4. How to find the memory size of any array (★☆☆)
+
 
 ```python
 Z = np.zeros((10,10))
@@ -37,89 +42,89 @@ print("%d bytes" % (Z.size * Z.itemsize))
 # Simpler alternative
 print("%d bytes" % Z.nbytes)
 ```
-
 #### 5. How to get the documentation of the numpy add function from the command line? (★☆☆)
+
 
 ```python
 %run `python -c "import numpy; numpy.info(numpy.add)"`
 ```
-
 #### 6. Create a null vector of size 10 but the fifth value which is 1 (★☆☆)
+
 
 ```python
 Z = np.zeros(10)
 Z[4] = 1
 print(Z)
 ```
-
 #### 7. Create a vector with values ranging from 10 to 49 (★☆☆)
+
 
 ```python
 Z = np.arange(10,50)
 print(Z)
 ```
-
 #### 8. Reverse a vector (first element becomes last) (★☆☆)
+
 
 ```python
 Z = np.arange(50)
 Z = Z[::-1]
 print(Z)
 ```
-
 #### 9. Create a 3x3 matrix with values ranging from 0 to 8 (★☆☆)
+
 
 ```python
 Z = np.arange(9).reshape(3, 3)
 print(Z)
 ```
-
 #### 10. Find indices of non-zero elements from [1,2,0,0,4,0] (★☆☆)
+
 
 ```python
 nz = np.nonzero([1,2,0,0,4,0])
 print(nz)
 ```
-
 #### 11. Create a 3x3 identity matrix (★☆☆)
+
 
 ```python
 Z = np.eye(3)
 print(Z)
 ```
-
 #### 12. Create a 3x3x3 array with random values (★☆☆)
+
 
 ```python
 Z = np.random.random((3,3,3))
 print(Z)
 ```
-
 #### 13. Create a 10x10 array with random values and find the minimum and maximum values (★☆☆)
+
 
 ```python
 Z = np.random.random((10,10))
 Zmin, Zmax = Z.min(), Z.max()
 print(Zmin, Zmax)
 ```
-
 #### 14. Create a random vector of size 30 and find the mean value (★☆☆)
+
 
 ```python
 Z = np.random.random(30)
 m = Z.mean()
 print(m)
 ```
-
 #### 15. Create a 2d array with 1 on the border and 0 inside (★☆☆)
+
 
 ```python
 Z = np.ones((10,10))
 Z[1:-1,1:-1] = 0
 print(Z)
 ```
-
 #### 16. How to add a border (filled with 0's) around an existing array? (★☆☆)
+
 
 ```python
 Z = np.ones((5,5))
@@ -131,9 +136,7 @@ Z[:, [0, -1]] = 0
 Z[[0, -1], :] = 0
 print(Z)
 ```
-
 #### 17. What is the result of the following expression? (★☆☆)
-
 ```python
 0 * np.nan
 np.nan == np.nan
@@ -143,6 +146,7 @@ np.nan in set([np.nan])
 0.3 == 3 * 0.1
 ```
 
+
 ```python
 print(0 * np.nan)
 print(np.nan == np.nan)
@@ -151,15 +155,15 @@ print(np.nan - np.nan)
 print(np.nan in set([np.nan]))
 print(0.3 == 3 * 0.1)
 ```
-
 #### 18. Create a 5x5 matrix with values 1,2,3,4 just below the diagonal (★☆☆)
+
 
 ```python
 Z = np.diag(1+np.arange(4),k=-1)
 print(Z)
 ```
-
 #### 19. Create a 8x8 matrix and fill it with a checkerboard pattern (★☆☆)
+
 
 ```python
 Z = np.zeros((8,8),dtype=int)
@@ -167,29 +171,29 @@ Z[1::2,::2] = 1
 Z[::2,1::2] = 1
 print(Z)
 ```
-
 #### 20. Consider a (6,7,8) shape array, what is the index (x,y,z) of the 100th element? (★☆☆)
+
 
 ```python
 print(np.unravel_index(99,(6,7,8)))
 ```
-
 #### 21. Create a checkerboard 8x8 matrix using the tile function (★☆☆)
+
 
 ```python
 Z = np.tile( np.array([[0,1],[1,0]]), (4,4))
 print(Z)
 ```
-
 #### 22. Normalize a 5x5 random matrix (★☆☆)
+
 
 ```python
 Z = np.random.random((5,5))
 Z = (Z - np.mean (Z)) / (np.std (Z))
 print(Z)
 ```
-
 #### 23. Create a custom dtype that describes a color as four unsigned bytes (RGBA) (★☆☆)
+
 
 ```python
 color = np.dtype([("r", np.ubyte),
@@ -197,8 +201,8 @@ color = np.dtype([("r", np.ubyte),
                   ("b", np.ubyte),
                   ("a", np.ubyte)])
 ```
-
 #### 24. Multiply a 5x3 matrix by a 3x2 matrix (real matrix product) (★☆☆)
+
 
 ```python
 Z = np.matmul(np.ones((5, 3)), np.ones((3, 2)))
@@ -208,8 +212,8 @@ print(Z)
 Z = np.ones((5,3)) @ np.ones((3,2))
 print(Z)
 ```
-
 #### 25. Given a 1D array, negate all elements which are between 3 and 8, in place. (★☆☆)
+
 
 ```python
 # Author: Evgeni Burovski
@@ -218,9 +222,7 @@ Z = np.arange(11)
 Z[(3 < Z) & (Z < 8)] *= -1
 print(Z)
 ```
-
 #### 26. What is the output of the following script? (★☆☆)
-
 ```python
 # Author: Jake VanderPlas
 
@@ -229,6 +231,7 @@ from numpy import *
 print(sum(range(5),-1))
 ```
 
+
 ```python
 # Author: Jake VanderPlas
 
@@ -236,9 +239,7 @@ print(sum(range(5),-1))
 from numpy import *
 print(sum(range(5),-1))
 ```
-
 #### 27. Consider an integer vector Z, which of these expressions are legal? (★☆☆)
-
 ```python
 Z**Z
 2 << Z >> 2
@@ -248,6 +249,7 @@ Z/1/1
 Z<Z>Z
 ```
 
+
 ```python
 Z**Z
 2 << Z >> 2
@@ -256,22 +258,21 @@ Z <- Z
 Z/1/1
 Z<Z>Z
 ```
-
 #### 28. What are the result of the following expressions? (★☆☆)
-
 ```python
 np.array(0) / np.array(0)
 np.array(0) // np.array(0)
 np.array([np.nan]).astype(int).astype(float)
 ```
 
+
 ```python
 print(np.array(0) / np.array(0))
 print(np.array(0) // np.array(0))
 print(np.array([np.nan]).astype(int).astype(float))
 ```
-
 #### 29. How to round away from zero a float array ? (★☆☆)
+
 
 ```python
 # Author: Charles R Harris
@@ -282,16 +283,16 @@ print(np.copysign(np.ceil(np.abs(Z)), Z))
 # More readable but less efficient
 print(np.where(Z>0, np.ceil(Z), np.floor(Z)))
 ```
-
 #### 30. How to find common values between two arrays? (★☆☆)
+
 
 ```python
 Z1 = np.random.randint(0,10,10)
 Z2 = np.random.randint(0,10,10)
 print(np.intersect1d(Z1,Z2))
 ```
-
 #### 31. How to ignore all numpy warnings (not recommended)? (★☆☆)
+
 
 ```python
 # Suicide mode on
@@ -305,33 +306,32 @@ _ = np.seterr(**defaults)
 with np.errstate(all="ignore"):
     np.arange(3) / 0
 ```
-
 #### 32. Is the following expressions true? (★☆☆)
-
 ```python
 np.sqrt(-1) == np.emath.sqrt(-1)
 ```
 
+
 ```python
 np.sqrt(-1) == np.emath.sqrt(-1)
 ```
-
 #### 33. How to get the dates of yesterday, today and tomorrow? (★☆☆)
+
 
 ```python
 yesterday = np.datetime64('today') - np.timedelta64(1)
 today     = np.datetime64('today')
 tomorrow  = np.datetime64('today') + np.timedelta64(1)
 ```
-
 #### 34. How to get all the dates corresponding to the month of July 2016? (★★☆)
+
 
 ```python
 Z = np.arange('2016-07', '2016-08', dtype='datetime64[D]')
 print(Z)
 ```
+#### 35. How to compute ((A+B)*(-A/2)) in place (without copy)? (★★☆)
 
-#### 35. How to compute ((A+B)\*(-A/2)) in place (without copy)? (★★☆)
 
 ```python
 A = np.ones(3)*1
@@ -341,8 +341,8 @@ np.divide(A,2,out=A)
 np.negative(A,out=A)
 np.multiply(A,B,out=A)
 ```
-
 #### 36. Extract the integer part of a random array of positive numbers using 4 different methods (★★☆)
+
 
 ```python
 Z = np.random.uniform(0,10,10)
@@ -353,8 +353,8 @@ print(np.floor(Z))
 print(Z.astype(int))
 print(np.trunc(Z))
 ```
-
 #### 37. Create a 5x5 matrix with row values ranging from 0 to 4 (★★☆)
+
 
 ```python
 Z = np.zeros((5,5))
@@ -365,8 +365,8 @@ print(Z)
 Z = np.tile(np.arange(0, 5), (5,1))
 print(Z)
 ```
-
 #### 38. Consider a generator function that generates 10 integers and use it to build an array (★☆☆)
+
 
 ```python
 def generate():
@@ -375,23 +375,23 @@ def generate():
 Z = np.fromiter(generate(),dtype=float,count=-1)
 print(Z)
 ```
-
 #### 39. Create a vector of size 10 with values ranging from 0 to 1, both excluded (★★☆)
+
 
 ```python
 Z = np.linspace(0,1,11,endpoint=False)[1:]
 print(Z)
 ```
-
 #### 40. Create a random vector of size 10 and sort it (★★☆)
+
 
 ```python
 Z = np.random.random(10)
 Z.sort()
 print(Z)
 ```
-
 #### 41. How to sum a small array faster than np.sum? (★★☆)
+
 
 ```python
 # Author: Evgeni Burovski
@@ -399,8 +399,8 @@ print(Z)
 Z = np.arange(10)
 np.add.reduce(Z)
 ```
-
 #### 42. Consider two random arrays A and B, check if they are equal (★★☆)
+
 
 ```python
 A = np.random.randint(0,2,5)
@@ -414,16 +414,16 @@ print(equal)
 equal = np.array_equal(A,B)
 print(equal)
 ```
-
 #### 43. Make an array immutable (read-only) (★★☆)
+
 
 ```python
 Z = np.zeros(10)
 Z.flags.writeable = False
 Z[0] = 1
 ```
-
 #### 44. Consider a random 10x2 matrix representing cartesian coordinates, convert them to polar coordinates (★★☆)
+
 
 ```python
 Z = np.random.random((10,2))
@@ -433,16 +433,16 @@ T = np.arctan2(Y,X)
 print(R)
 print(T)
 ```
-
 #### 45. Create random vector of size 10 and replace the maximum value by 0 (★★☆)
+
 
 ```python
 Z = np.random.random(10)
 Z[Z.argmax()] = 0
 print(Z)
 ```
-
 #### 46. Create a structured array with `x` and `y` coordinates covering the [0,1]x[0,1] area (★★☆)
+
 
 ```python
 Z = np.zeros((5,5), [('x',float),('y',float)])
@@ -450,8 +450,8 @@ Z['x'], Z['y'] = np.meshgrid(np.linspace(0,1,5),
                              np.linspace(0,1,5))
 print(Z)
 ```
-
 #### 47. Given two arrays, X and Y, construct the Cauchy matrix C (Cij =1/(xi - yj)) (★★☆)
+
 
 ```python
 # Author: Evgeni Burovski
@@ -461,8 +461,8 @@ Y = X + 0.5
 C = 1.0 / np.subtract.outer(X, Y)
 print(np.linalg.det(C))
 ```
-
 #### 48. Print the minimum and maximum representable values for each numpy scalar type (★★☆)
+
 
 ```python
 for dtype in [np.int8, np.int32, np.int64]:
@@ -473,16 +473,16 @@ for dtype in [np.float32, np.float64]:
    print(np.finfo(dtype).max)
    print(np.finfo(dtype).eps)
 ```
-
 #### 49. How to print all the values of an array? (★★☆)
+
 
 ```python
 np.set_printoptions(threshold=float("inf"))
 Z = np.zeros((40,40))
 print(Z)
 ```
-
 #### 50. How to find the closest value (to a given scalar) in a vector? (★★☆)
+
 
 ```python
 Z = np.arange(100)
@@ -490,8 +490,8 @@ v = np.random.uniform(0,100)
 index = (np.abs(Z-v)).argmin()
 print(Z[index])
 ```
-
 #### 51. Create a structured array representing a position (x,y) and a color (r,g,b) (★★☆)
+
 
 ```python
 Z = np.zeros(10, [ ('position', [ ('x', float, 1),
@@ -501,8 +501,8 @@ Z = np.zeros(10, [ ('position', [ ('x', float, 1),
                                   ('b', float, 1)])])
 print(Z)
 ```
-
 #### 52. Consider a random vector with shape (100,2) representing coordinates, find point by point distances (★★☆)
+
 
 ```python
 Z = np.random.random((10,2))
@@ -519,8 +519,8 @@ Z = np.random.random((10,2))
 D = scipy.spatial.distance.cdist(Z,Z)
 print(D)
 ```
-
 #### 53. How to convert a float (32 bits) array into an integer (32 bits) array in place?
+
 
 ```python
 # Thanks Vikas (https://stackoverflow.com/a/10622758/5989906)
@@ -530,30 +530,27 @@ Y = Z.view(np.int32)
 Y[:] = Z
 print(Y)
 ```
-
 #### 54. How to read the following file? (★★☆)
-
 ```
 1, 2, 3, 4, 5
 6,  ,  , 7, 8
  ,  , 9,10,11
 ```
 
+
 ```python
 import numpy as np
 from io import StringIO
 
+# Added filling_values to handle missing entries safely
 s = StringIO('''1, 2, 3, 4, 5
                 6,  ,  , 7, 8
                  ,  , 9,10,11''')
 Z = np.genfromtxt(s, delimiter=",", dtype=int, filling_values=0)
-                 ,  , 9,10,11''')
-Z = np.genfromtxt(s, delimiter=",", dtype=int, filling_values=0)
 print(Z)
 ```
-
-
 #### 55. What is the equivalent of enumerate for numpy arrays? (★★☆)
+
 
 ```python
 Z = np.arange(9).reshape(3,3)
@@ -562,9 +559,8 @@ for index, value in np.ndenumerate(Z):
 for index in np.ndindex(Z.shape):
     print(index, Z[index])
 ```
-
-
 #### 56. Generate a generic 2D Gaussian-like array (★★☆)
+
 
 ```python
 X, Y = np.meshgrid(np.linspace(-1,1,10), np.linspace(-1,1,10))
@@ -573,8 +569,8 @@ sigma, mu = 1.0, 0.0
 G = np.exp(-( (D-mu)**2 / ( 2.0 * sigma**2 ) ) )
 print(G)
 ```
-
 #### 57. How to randomly place p elements in a 2D array? (★★☆)
+
 
 ```python
 # Author: Divakar
@@ -585,8 +581,8 @@ Z = np.zeros((n,n))
 np.put(Z, np.random.choice(range(n*n), p, replace=False),1)
 print(Z)
 ```
-
 #### 58. Subtract the mean of each row of a matrix (★★☆)
+
 
 ```python
 # Author: Warren Weckesser
@@ -601,8 +597,8 @@ Y = X - X.mean(axis=1).reshape(-1, 1)
 
 print(Y)
 ```
-
 #### 59. How to sort an array by the nth column? (★★☆)
+
 
 ```python
 # Author: Steve Tjoa
@@ -611,13 +607,13 @@ Z = np.random.randint(0,10,(3,3))
 print(Z)
 print(Z[Z[:,1].argsort()])
 ```
-
 #### 60. How to tell if a given 2D array has null columns? (★★☆)
+
 
 ```python
 # Author: Warren Weckesser
 
-# null : 0
+# null : 0 
 Z = np.random.randint(0,3,(3,10))
 print((~Z.any(axis=0)).any())
 
@@ -629,8 +625,8 @@ Z=np.array([
 ])
 print(np.isnan(Z).all(axis=0))
 ```
-
 #### 61. Find the nearest value from a given value in an array (★★☆)
+
 
 ```python
 Z = np.random.uniform(0,1,10)
@@ -638,8 +634,8 @@ z = 0.5
 m = Z.flat[np.abs(Z - z).argmin()]
 print(m)
 ```
-
 #### 62. Considering two arrays with shape (1,3) and (3,1), how to compute their sum using an iterator? (★★☆)
+
 
 ```python
 A = np.arange(3).reshape(3,1)
@@ -648,8 +644,8 @@ it = np.nditer([A,B,None])
 for x,y,z in it: z[...] = x + y
 print(it.operands[2])
 ```
-
 #### 63. Create an array class that has a name attribute (★★☆)
+
 
 ```python
 class NamedArray(np.ndarray):
@@ -664,8 +660,8 @@ class NamedArray(np.ndarray):
 Z = NamedArray(np.arange(10), "range_10")
 print (Z.name)
 ```
-
 #### 64. Consider a given vector, how to add 1 to each element indexed by a second vector (be careful with repeated indices)? (★★★)
+
 
 ```python
 # Author: Brett Olsen
@@ -680,8 +676,8 @@ print(Z)
 np.add.at(Z, I, 1)
 print(Z)
 ```
-
 #### 65. How to accumulate elements of a vector (X) to an array (F) based on an index list (I)? (★★★)
+
 
 ```python
 # Author: Alan G Isaac
@@ -691,8 +687,8 @@ I = [1,3,9,3,4,1]
 F = np.bincount(I,X)
 print(F)
 ```
-
 #### 66. Considering a (w,h,3) image of (dtype=ubyte), compute the number of unique colors (★★☆)
+
 
 ```python
 # Author: Fisher Wang
@@ -717,8 +713,8 @@ I24 = np.dot(I.astype(np.uint32),[1,256,65536])
 n = len(np.unique(I24))
 print(n)
 ```
-
 #### 67. Considering a four dimensions array, how to get sum over the last two axis at once? (★★★)
+
 
 ```python
 A = np.random.randint(0,10,(3,4,3,4))
@@ -730,8 +726,8 @@ print(sum)
 sum = A.reshape(A.shape[:-2] + (-1,)).sum(axis=-1)
 print(sum)
 ```
+#### 68. Considering a one-dimensional vector D, how to compute means of subsets of D using a vector S of same size describing subset  indices? (★★★)
 
-#### 68. Considering a one-dimensional vector D, how to compute means of subsets of D using a vector S of same size describing subset indices? (★★★)
 
 ```python
 # Author: Jaime Fernández del Río
@@ -747,8 +743,8 @@ print(D_means)
 import pandas as pd
 print(pd.Series(D).groupby(S).mean())
 ```
-
 #### 69. How to get the diagonal of a dot product? (★★★)
+
 
 ```python
 # Author: Mathieu Blondel
@@ -765,8 +761,8 @@ np.sum(A * B.T, axis=1)
 # Faster version
 np.einsum("ij,ji->i", A, B)
 ```
-
 #### 70. Consider the vector [1, 2, 3, 4, 5], how to build a new vector with 3 consecutive zeros interleaved between each value? (★★★)
+
 
 ```python
 # Author: Warren Weckesser
@@ -777,16 +773,16 @@ Z0 = np.zeros(len(Z) + (len(Z)-1)*(nz))
 Z0[::nz+1] = Z
 print(Z0)
 ```
-
 #### 71. Consider an array of dimension (5,5,3), how to multiply it by an array with dimensions (5,5)? (★★★)
+
 
 ```python
 A = np.ones((5,5,3))
 B = 2*np.ones((5,5))
 print(A * B[:,:,None])
 ```
-
 #### 72. How to swap two rows of an array? (★★★)
+
 
 ```python
 # Author: Eelco Hoogendoorn
@@ -795,8 +791,8 @@ A = np.arange(25).reshape(5,5)
 A[[0,1]] = A[[1,0]]
 print(A)
 ```
+#### 73. Consider a set of 10 triplets describing 10 triangles (with shared vertices), find the set of unique line segments composing all the  triangles (★★★)
 
-#### 73. Consider a set of 10 triplets describing 10 triangles (with shared vertices), find the set of unique line segments composing all the triangles (★★★)
 
 ```python
 # Author: Nicolas P. Rougier
@@ -809,8 +805,8 @@ G = F.view( dtype=[('p0',F.dtype),('p1',F.dtype)] )
 G = np.unique(G)
 print(G)
 ```
-
 #### 74. Given a sorted array C that corresponds to a bincount, how to produce an array A such that np.bincount(A) == C? (★★★)
+
 
 ```python
 # Author: Jaime Fernández del Río
@@ -819,8 +815,8 @@ C = np.bincount([1,1,2,3,4,4,6])
 A = np.repeat(np.arange(len(C)), C)
 print(A)
 ```
-
 #### 75. How to compute averages using a sliding window over an array? (★★★)
+
 
 ```python
 # Author: Jaime Fernández del Río
@@ -840,8 +836,8 @@ from numpy.lib.stride_tricks import sliding_window_view
 Z = np.arange(20)
 print(sliding_window_view(Z, window_shape=3).mean(axis=-1))
 ```
+#### 76. Consider a one-dimensional array Z, build a two-dimensional array whose first row is (Z[0],Z[1],Z[2]) and each subsequent row is  shifted by 1 (last row should be (Z[-3],Z[-2],Z[-1]) (★★★)
 
-#### 76. Consider a one-dimensional array Z, build a two-dimensional array whose first row is (Z[0],Z[1],Z[2]) and each subsequent row is shifted by 1 (last row should be (Z[-3],Z[-2],Z[-1]) (★★★)
 
 ```python
 # Author: Joe Kington / Erik Rigtorp
@@ -859,8 +855,8 @@ print(Z)
 Z = np.arange(10)
 print(sliding_window_view(Z, window_shape=3))
 ```
-
 #### 77. How to negate a boolean, or to change the sign of a float inplace? (★★★)
+
 
 ```python
 # Author: Nathaniel J. Smith
@@ -871,8 +867,8 @@ np.logical_not(Z, out=Z)
 Z = np.random.uniform(-1.0,1.0,100)
 np.negative(Z, out=Z)
 ```
-
 #### 78. Consider 2 sets of points P0,P1 describing lines (2d) and a point p, how to compute distance from p to each line i (P0[i],P1[i])? (★★★)
+
 
 ```python
 P0 = np.random.uniform(-10,10,(10,2))
@@ -883,12 +879,12 @@ def distance_faster(P0,P1,p):
     #Author: Hemanth Pasupuleti
     #Reference: https://mathworld.wolfram.com/Point-LineDistance2-Dimensional.html
 
-    v = P1- P0
+    v = P1- P0 
     v[:,[0,1]] = v[:,[1,0]]
-    v[:,1]*=-1
-    norm = np.linalg.norm(v,axis=1)
+    v[:,1]*=-1 
+    norm = np.linalg.norm(v,axis=1)   
     r = P0 - p
-    d = np.abs(np.einsum("ij,ij->i",r,v)) / norm
+    d = np.abs(np.einsum("ij,ij->i",r,v)) / norm 
 
     return d
 
@@ -905,8 +901,8 @@ def distance_slower(P0, P1, p):
 
 print(distance_slower(P0, P1, p))
 ```
-
 #### 79. Consider 2 sets of points P0,P1 describing lines (2d) and a set of points P, how to compute distance from each point j (P[j]) to each line i (P0[i],P1[i])? (★★★)
+
 
 ```python
 # Author: Italmassov Kuanysh
@@ -943,8 +939,8 @@ def distance_points_to_lines(p: np.ndarray, p_1: np.ndarray, p_2: np.ndarray) ->
 
 distance_points_to_lines(p, P0, P1)
 ```
-
 #### 80. Consider an arbitrary array, write a function that extracts a subpart with a fixed shape and centered on a given element (pad with a `fill` value when necessary) (★★★)
+
 
 ```python
 # Author: Nicolas Rougier
@@ -975,8 +971,8 @@ R[r] = Z[z]
 print(Z)
 print(R)
 ```
-
 #### 81. Consider an array Z = [1,2,3,4,5,6,7,8,9,10,11,12,13,14], how to generate an array R = [[1,2,3,4], [2,3,4,5], [3,4,5,6], ..., [11,12,13,14]]? (★★★)
+
 
 ```python
 # Author: Stefan van der Walt
@@ -990,8 +986,8 @@ print(R)
 Z = np.arange(1, 15, dtype=np.uint32)
 print(sliding_window_view(Z, window_shape=4))
 ```
-
 #### 82. Compute a matrix rank (★★★)
+
 
 ```python
 # Author: Stefan van der Walt
@@ -1008,15 +1004,15 @@ print(rank)
 rank = np.linalg.matrix_rank(Z)
 print(rank)
 ```
-
 #### 83. How to find the most frequent value in an array?
+
 
 ```python
 Z = np.random.randint(0,10,50)
 print(np.bincount(Z).argmax())
 ```
-
 #### 84. Extract all the contiguous 3x3 blocks from a random 10x10 matrix (★★★)
+
 
 ```python
 # Author: Chris Barker
@@ -1033,8 +1029,8 @@ print(C)
 Z = np.random.randint(0,5,(10,10))
 print(sliding_window_view(Z, window_shape=(3, 3)))
 ```
-
 #### 85. Create a 2D array subclass such that Z[i,j] == Z[j,i] (★★★)
+
 
 ```python
 # Author: Eric O. Lebigot
@@ -1053,8 +1049,8 @@ S = symetric(np.random.randint(0,10,(5,5)))
 S[2,3] = 42
 print(S)
 ```
-
 #### 86. Consider a set of p matrices with shape (n,n) and a set of p vectors with shape (n,1). How to compute the sum of of the p matrix products at once? (result has shape (n,1)) (★★★)
+
 
 ```python
 # Author: Stefan van der Walt
@@ -1071,8 +1067,8 @@ print(S)
 # Thus, summing over the paired axes 0 and 0 (of M and V independently),
 # and 2 and 1, to remain with a (n,1) vector.
 ```
-
 #### 87. Consider a 16x16 array, how to get the block-sum (block size is 4x4)? (★★★)
+
 
 ```python
 # Author: Robert Kern
@@ -1095,8 +1091,8 @@ S = windows[::k, ::k, ...].sum(axis=(-2, -1))
 # alternative solution (by @Gattocrucco)
 S = Z.reshape(4, 4, 4, 4).sum((1, 3))
 ```
-
 #### 88. How to implement the Game of Life using numpy arrays? (★★★)
+
 
 ```python
 # Author: Nicolas Rougier
@@ -1118,8 +1114,8 @@ Z = np.random.randint(0,2,(50,50))
 for i in range(100): Z = iterate(Z)
 print(Z)
 ```
-
 #### 89. How to get the n largest values of an array (★★★)
+
 
 ```python
 Z = np.arange(10000)
@@ -1132,8 +1128,8 @@ print (Z[np.argsort(Z)[-n:]])
 # Fast
 print (Z[np.argpartition(-Z,n)[:n]])
 ```
-
 #### 90. Given an arbitrary number of vectors, build the cartesian product (every combination of every item) (★★★)
+
 
 ```python
 # Author: Stefan Van der Walt
@@ -1152,8 +1148,8 @@ def cartesian(arrays):
 
 print (cartesian(([1, 2, 3], [4, 5], [6, 7])))
 ```
-
 #### 91. How to create a record array from a regular array? (★★★)
+
 
 ```python
 Z = np.array([("Hello", 2.5, 3),
@@ -1163,8 +1159,8 @@ R = np.core.records.fromarrays(Z.T,
                                formats = 'S8, f8, i8')
 print(R)
 ```
-
 #### 92. Consider a large vector Z, compute Z to the power of 3 using 3 different methods (★★★)
+
 
 ```python
 # Author: Ryan G.
@@ -1175,8 +1171,8 @@ x = np.random.rand(int(5e7))
 %timeit x*x*x
 %timeit np.einsum('i,i,i->i',x,x,x)
 ```
-
 #### 93. Consider two arrays A and B of shape (8,3) and (2,2). How to find rows of A that contain elements of each row of B regardless of the order of the elements in B? (★★★)
+
 
 ```python
 # Author: Gabe Schwartz
@@ -1188,8 +1184,8 @@ C = (A[..., np.newaxis, np.newaxis] == B)
 rows = np.where(C.any((3,1)).all(1))[0]
 print(rows)
 ```
-
 #### 94. Considering a 10x3 matrix, extract rows with unequal values (e.g. [2,2,3]) (★★★)
+
 
 ```python
 # Author: Robert Kern
@@ -1204,8 +1200,8 @@ print(U)
 U = Z[Z.max(axis=1) != Z.min(axis=1),:]
 print(U)
 ```
-
 #### 95. Convert a vector of ints into a matrix binary representation (★★★)
+
 
 ```python
 # Author: Warren Weckesser
@@ -1219,8 +1215,8 @@ print(B[:,::-1])
 I = np.array([0, 1, 2, 3, 15, 16, 32, 64, 128], dtype=np.uint8)
 print(np.unpackbits(I[:, np.newaxis], axis=1))
 ```
-
 #### 96. Given a two dimensional array, how to extract unique rows? (★★★)
+
 
 ```python
 # Author: Jaime Fernández del Río
@@ -1236,8 +1232,8 @@ print(uZ)
 uZ = np.unique(Z, axis=0)
 print(uZ)
 ```
-
 #### 97. Considering 2 vectors A & B, write the einsum equivalent of inner, outer, sum, and mul function (★★★)
+
 
 ```python
 # Author: Alex Riley
@@ -1251,8 +1247,8 @@ np.einsum('i,i->i', A, B) # A * B
 np.einsum('i,i', A, B)    # np.inner(A, B)
 np.einsum('i,j->ij', A, B)    # np.outer(A, B)
 ```
-
 #### 98. Considering a path described by two vectors (X,Y), how to sample it using equidistant samples (★★★)?
+
 
 ```python
 # Author: Bas Swinckels
@@ -1269,8 +1265,8 @@ r_int = np.linspace(0, r.max(), 200) # regular spaced path
 x_int = np.interp(r_int, r, x)       # integrate path
 y_int = np.interp(r_int, r, y)
 ```
-
 #### 99. Given an integer n and a 2D array X, select from X the rows which can be interpreted as draws from a multinomial distribution with n degrees, i.e., the rows which only contain integers and which sum to n. (★★★)
+
 
 ```python
 # Author: Evgeni Burovski
@@ -1283,8 +1279,8 @@ M = np.logical_and.reduce(np.mod(X, 1) == 0, axis=-1)
 M &= (X.sum(axis=-1) == n)
 print(X[M])
 ```
-
 #### 100. Compute bootstrapped 95% confidence intervals for the mean of a 1D array X (i.e., resample the elements of an array with replacement N times, compute the mean of each sample, and then compute percentiles over the means). (★★★)
+
 
 ```python
 # Author: Jessica B. Hamrick


### PR DESCRIPTION
This PR fixes issue #247 by addressing two related problems in the markdown example:

1. **Handled missing values** — added `filling_values=0` in `np.genfromtxt` to prevent  
   `ValueError: invalid literal for int() with base 10: ''`.

2. **Resolved deprecated alias usage** — replaced `dtype=int` instead of `dtype=np.int`  
   to fix `AttributeError: module 'numpy' has no attribute 'int'`.

Both changes ensure compatibility with newer NumPy versions and prevent runtime errors when parsing incomplete CSV data in the provided example.