### PR TITLE
Clarify Q93 wording: at least one element per row, fixes #226

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -1444,7 +1444,7 @@ x = np.random.rand(int(5e7))
 %timeit np.einsum('i,i,i->i',x,x,x)
 
 < q93
-Consider two arrays A and B of shape (8,3) and (2,2). How to find rows of A that contain elements of each row of B regardless of the order of the elements in B? (★★★)
+Consider two arrays A and B of shape (8,3) and (2,2). How to find rows of A that contain at least one element of each row of B regardless of the order of the elements in B?
 
 < h93
 hint: np.where


### PR DESCRIPTION
This PR clarifies the ambiguous wording in Q93, specifying that a row of A only needs to contain at least one element from each row of B, not all elements. Fixes #226