### PR TITLE
Fix exercise 51: deprecated (type, 1) structured dtype -> scalar fields

### DIFF
--- a/source/exercises100.ktx
+++ b/source/exercises100.ktx
@@ -633,11 +633,11 @@ Create a structured array representing a position (x,y) and a color (r,g,b) (★
 hint: dtype
 
 < a51
-Z = np.zeros(10, [ ('position', [ ('x', float, 1),
-                                  ('y', float, 1)]),
-                   ('color',    [ ('r', float, 1),
-                                  ('g', float, 1),
-                                  ('b', float, 1)])])
+Z = np.zeros(10, [ ('position', [ ('x', float),
+                                  ('y', float)]),
+                   ('color',    [ ('r', float),
+                                  ('g', float),
+                                  ('b', float)])])
 print(Z)
 
 < q52


### PR DESCRIPTION
Exercise 51's solution uses the deprecated `('x', float, 1)` structured-dtype syntax. On NumPy >= 2.x this silently became a length-1 subarray (`('x', float, (1,))`) instead of a scalar field, and on older NumPy it raised a `FutureWarning`. Dropped the count so the fields are scalars again.

Edited the source (`source/exercises100.ktx`) and regenerated the solution markdown via `generators.py`.
