### PR TITLE
Clarify normalization method in exercise 22

### DIFF
--- a/100_Numpy_exercises_with_hints_with_solutions.md
+++ b/100_Numpy_exercises_with_hints_with_solutions.md
@@ -184,8 +184,8 @@ print(np.unravel_index(99,(6,7,8)))
 Z = np.tile( np.array([[0,1],[1,0]]), (4,4))
 print(Z)
 ```
-#### 22. Normalize a 5x5 random matrix (★☆☆)
-`hint: (x -mean)/std`
+#### 22. Normalize a 5x5 random matrix using Z-score normalization (standardization) (★☆☆)
+`hint: Use Z-score normalization: (x - mean) / std`
 
 ```python
 Z = np.random.random((5,5))


### PR DESCRIPTION
This PR clarifies that Exercise 22 uses Z-score normalization (standardization).

The original wording was ambiguous because "normalize" can refer to multiple methods. The hint and solution use (x - mean) / std, so this change makes the expected method explicit.